### PR TITLE
Clear BTC wallet data after wallet switches

### DIFF
--- a/src/components/main.js
+++ b/src/components/main.js
@@ -434,6 +434,7 @@ class Main extends React.Component {
       if (err)
         return this.setError({ msg: err, cb: this.refreshWallets })
       this.setError();
+      this.fetchBtcData()
     })
   }
 


### PR DESCRIPTION
Adds a poll to refresh the user's wallet every 8 minutes or so. 

While refreshing, the entire UI is taken over by the refresh loader. I'm not sure if this user experience is worth the refreshing action. 

We can't refresh without the UI take-over, because the user could be in the middle of an action and swapping out the data out from under them could lead to them performing undesirable actions.  

Fixes #187