### PR TITLE
Fixes Third party connections no longer showing up

### DIFF
--- a/src/components/main.js
+++ b/src/components/main.js
@@ -108,8 +108,7 @@ class Main extends React.Component {
       this.setState({ hwCheck })
     } else {
       // Lookup deviceID and pw from storage
-      const deviceID = localStorage.getWalletId()
-      const password = localStorage.getWalletPassword()
+      const { deviceID, password } = localStorage.getLogin()
       if (deviceID && password)
         this.connect(deviceID, password, () => this.connectSession())
     }
@@ -244,8 +243,7 @@ class Main extends React.Component {
     this.unwait();
     this.state.session.disconnect();
     this.setState({ session: null });
-    localStorage.removeWalletId()
-    localStorage.removeWalletPassword()
+    localStorage.removeLogin()
     if (err && err === constants.LOST_PAIRING_MSG)
       this.setError({ err })
   }
@@ -299,8 +297,7 @@ class Main extends React.Component {
           // We connected!
           // 1. Save these credentials to localStorage if this is NOT a keyring
           if (!this.state.openedByKeyring) {
-            localStorage.setWalletId(deviceID);
-            localStorage.setWalletPassword(password);
+            localStorage.setLogin({ deviceID, password })
           }
           // 2. Clear errors and alerts
           this.setError();

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -12,7 +12,8 @@ import {
   Connect, Error, Landing, Loading, Pair, Permissions, Send, 
   Receive, Wallet, EthContracts, Settings, ValidateSig, KvFiles 
 } from './index'
-import { constants, getLocalStorageSettings, getBtcPurpose } from '../util/helpers'
+import { constants, getBtcPurpose } from '../util/helpers'
+import localStorage from '../util/localStorage';
 const { Content, Footer, Sider } = Layout;
 const LOGIN_PARAM = 'loginCache';
 const DEFAULT_MENU_ITEM = 'menu-landing';
@@ -91,7 +92,7 @@ class Main extends React.Component {
       window.onload = this.handleKeyringOpener();
       this.setState({ name: keyringName }, () => {
         // Check if this keyring has already logged in. This login should expire after a period of time.
-        const prevKeyringLogin = this.getPrevKeyringLogin();
+        const prevKeyringLogin = localStorage.getKeyringItem(keyringName);
         const keyringTimeoutBoundary = new Date().getTime() - constants.KEYRING_LOGOUT_MS;
         if (!forceLogin && prevKeyringLogin && prevKeyringLogin.lastLogin > keyringTimeoutBoundary) {
           this.connect( prevKeyringLogin.deviceID, 
@@ -99,7 +100,7 @@ class Main extends React.Component {
                         () => this.connectSession(prevKeyringLogin));
         } else {
           // If the login has expired, clear it now.
-          this.clearPrevKeyringLogin();
+          localStorage.removeKeyringItem(keyringName)
         }
       })
     } else if (hwCheck) {
@@ -107,8 +108,8 @@ class Main extends React.Component {
       this.setState({ hwCheck })
     } else {
       // Lookup deviceID and pw from storage
-      const deviceID = window.localStorage.getItem('gridplus_web_wallet_id');
-      const password = window.localStorage.getItem('gridplus_web_wallet_password');
+      const deviceID = localStorage.getWalletId()
+      const password = localStorage.getWalletPassword()
       if (deviceID && password)
         this.connect(deviceID, password, () => this.connectSession())
     }
@@ -140,7 +141,7 @@ class Main extends React.Component {
     const updates = { deviceID, password };
     if (!this.state.session) {
       // Create a new session if we don't have one.
-      const settings = JSON.parse(window.localStorage.getItem(constants.ROOT_STORE) || '{}').settings || {};
+      const settings = localStorage.getSettings()
       updates.session = new SDKSession(deviceID, this.setError, this.state.name, settings);
     }
     this.setState(updates, cb);
@@ -168,51 +169,6 @@ class Main extends React.Component {
   // KEYRING HANDLERS
   //------------------------------------------
 
-  saveKeyringLogin() {
-    if (this.state.name) {
-      const _storage = window.localStorage.getItem(constants.ROOT_STORE) || JSON.stringify({});
-      try {
-        const storage = JSON.parse(_storage);
-        if (!storage.settings)
-          storage.settings = {};
-        if (!storage.settings.keyringLogins)
-          storage.settings.keyringLogins = {};
-        storage.settings.keyringLogins[this.state.name] = {
-          deviceID: this.state.deviceID,
-          password: this.state.password,
-          lastLogin: new Date().getTime()
-        }
-        window.localStorage.setItem(constants.ROOT_STORE, JSON.stringify(storage));
-      } catch (err) {
-        console.error(`Error saving keyring login: ${err.toString()}`)
-      }
-    }
-  }
-
-  getPrevKeyringLogin() {
-    if (this.state.name) {
-      const _storage = window.localStorage.getItem(constants.ROOT_STORE);
-      try {
-        const storage = JSON.parse(_storage);
-        return storage.settings.keyringLogins[this.state.name];
-      } catch (e) {
-        return {};
-      }
-    }
-  }
-
-  clearPrevKeyringLogin() {
-    if (this.state.name) {
-      const _storage = window.localStorage.getItem(constants.ROOT_STORE);
-      try {
-        const storage = JSON.parse(_storage);
-        delete storage.settings.keyringLogins[this.state.name];
-      } catch (err) {
-        console.error(`Error clearing keyring login: ${err.toString()}`)
-      }
-    }
-  }
-
   handleKeyringOpener() {
     this.setState({ openedByKeyring: true })
   }
@@ -221,7 +177,11 @@ class Main extends React.Component {
     if (!this.state.openedByKeyring)
       return;
     // Save the login for later
-    this.saveKeyringLogin();
+    localStorage.setKeyringItem(this.state.name, {
+      deviceID: this.state.deviceID,
+      password: this.state.password,
+      lastLogin: new Date().getTime()
+    })
     // Send the data back to the opener
     const data = {
       deviceID: this.state.deviceID,
@@ -229,7 +189,7 @@ class Main extends React.Component {
       endpoint: constants.BASE_SIGNING_URL,
     };
     // Check if there is a custom endpoint configured
-    const settings = getLocalStorageSettings();
+    const settings = localStorage.getSettings();
     if (settings.customEndpoint && settings.customEndpoint !== '') {
       data.endpoint = settings.customEndpoint;
     }
@@ -284,8 +244,8 @@ class Main extends React.Component {
     this.unwait();
     this.state.session.disconnect();
     this.setState({ session: null });
-    window.localStorage.removeItem('gridplus_web_wallet_id');
-    window.localStorage.removeItem('gridplus_web_wallet_password');
+    localStorage.removeWalletId()
+    localStorage.removeWalletPassword()
     if (err && err === constants.LOST_PAIRING_MSG)
       this.setError({ err })
   }
@@ -339,8 +299,8 @@ class Main extends React.Component {
           // We connected!
           // 1. Save these credentials to localStorage if this is NOT a keyring
           if (!this.state.openedByKeyring) {
-            window.localStorage.setItem('gridplus_web_wallet_id', deviceID);
-            window.localStorage.setItem('gridplus_web_wallet_password', password);
+            localStorage.setWalletId(deviceID);
+            localStorage.setWalletPassword(password);
           }
           // 2. Clear errors and alerts
           this.setError();

--- a/src/util/__test__/localStorage.test.js
+++ b/src/util/__test__/localStorage.test.js
@@ -1,0 +1,61 @@
+import localStorage from "../localStorage";
+
+const key = "test";
+const value = 1;
+const obj = { [key]: value };
+
+describe("localStorage", () => {
+  test("should store data", () => {
+    localStorage.setItem(key, value);
+    expect(localStorage.getItem(key)).toStrictEqual(value);
+    localStorage.removeItem(key);
+    expect(localStorage.getItem(key)).toBe(null);
+  });
+
+  test("should store root data", () => {
+    localStorage.setRootStore(obj);
+    expect(localStorage.getRootStore()).toStrictEqual(obj);
+    localStorage.removeRootStore();
+    expect(localStorage.getRootStore()).toStrictEqual({});
+  });
+
+  test("should store root data item", () => {
+    localStorage.setRootStoreItem(key, value);
+    expect(localStorage.getRootStoreItem(key)).toStrictEqual(value);
+    localStorage.setRootStoreItem(key, obj);
+    expect(localStorage.getRootStoreItem(key)).toStrictEqual(obj);
+    localStorage.removeRootStoreItem(key);
+    expect(localStorage.getRootStoreItem(key)).toStrictEqual({});
+  });
+
+  test("should store settings", () => {
+    localStorage.setSettings(obj);
+    expect(localStorage.getSettings()).toStrictEqual(obj);
+  });
+
+  test("should get keyring", () => {
+    localStorage.setRootStoreItem("keyring", obj);
+    expect(localStorage.getKeyring()).toStrictEqual(obj);
+  });
+
+  test("should store keyring items", () => {
+    localStorage.setKeyringItem(key, obj);
+    expect(localStorage.getKeyringItem(key)).toStrictEqual(obj);
+    localStorage.removeKeyringItem(key);
+    expect(localStorage.getKeyringItem(key)).toStrictEqual({});
+  });
+
+  test("should store walletId", () => {
+    localStorage.setWalletId(value);
+    expect(localStorage.getWalletId()).toStrictEqual(value);
+    localStorage.removeWalletId();
+    expect(localStorage.getWalletId()).toBe(null);
+  });
+
+  test("should store walletPassword", () => {
+    localStorage.setWalletPassword(value);
+    expect(localStorage.getWalletPassword()).toStrictEqual(value);
+    localStorage.removeWalletPassword();
+    expect(localStorage.getWalletPassword()).toBe(null);
+  });
+});

--- a/src/util/__test__/localStorage.test.js
+++ b/src/util/__test__/localStorage.test.js
@@ -45,17 +45,24 @@ describe("localStorage", () => {
     expect(localStorage.getKeyringItem(key)).toStrictEqual({});
   });
 
-  test("should store walletId", () => {
-    localStorage.setWalletId(value);
-    expect(localStorage.getWalletId()).toStrictEqual(value);
-    localStorage.removeWalletId();
-    expect(localStorage.getWalletId()).toBe(null);
+  test("should store loginId", () => {
+    localStorage.setLoginId(value);
+    expect(localStorage.getLoginId()).toStrictEqual(value);
+    localStorage.removeLoginId();
+    expect(localStorage.getLoginId()).toBe(null);
   });
 
-  test("should store walletPassword", () => {
-    localStorage.setWalletPassword(value);
-    expect(localStorage.getWalletPassword()).toStrictEqual(value);
-    localStorage.removeWalletPassword();
-    expect(localStorage.getWalletPassword()).toBe(null);
+  test("should store loginPassword", () => {
+    localStorage.setLoginPassword(value);
+    expect(localStorage.getLoginPassword()).toStrictEqual(value);
+    localStorage.removeLoginPassword();
+    expect(localStorage.getLoginPassword()).toBe(null);
+  });
+
+  test("should store login", () => {
+    localStorage.setLogin({deviceID: key, password: value});
+    expect(localStorage.getLogin()).toStrictEqual({deviceID: key, password: value});
+    localStorage.removeLogin();
+    expect(localStorage.getLogin()).toStrictEqual({deviceID: null, password: null});
   });
 });

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -10,7 +10,6 @@ export const constants = {
     BASE_SIGNING_URL: process.env.REACT_APP_BASE_SIGNING_URL || 'https://signing.gridpl.us',
     BTC_PROD_DATA_API: 'https://blockchain.info',
     BTC_BROADCAST_ENDPOINT: 'https://blockstream.info/api/tx',
-    ROOT_STORE: process.env.REACT_APP_ROOT_STORE || 'gridplus',
     HARDENED_OFFSET,
     ASYNC_SDK_TIMEOUT: 60000,
     SHORT_TIMEOUT: 30000,
@@ -18,8 +17,6 @@ export const constants = {
     SATS_TO_BTC: Math.pow(10, 8),
     BTC_MAIN_GAP_LIMIT: 20,
     BTC_CHANGE_GAP_LIMIT: 1,
-    WALLET_ID_STORAGE_KEY: 'gridplus_web_wallet_id',
-    WALLET_PASSWORD_STORAGE_KEY: 'gridplus_web_wallet_password',
     BTC_ADDR_BLOCK_LEN: 10,
     BTC_CHANGE_ADDR_BLOCK_LEN: 1,
     BTC_DEFAULT_FEE_RATE: process.env.REACT_APP_BTC_DEFAULT_FEE_RATE || 10, // 10 sat/byte

--- a/src/util/localStorage.js
+++ b/src/util/localStorage.js
@@ -33,7 +33,7 @@ const setSettings = (value) => setRootStoreItem("settings", value);
 
 const getKeyring = () => getRootStoreItem("keyring");
 
-const getKeyringItem = (key) => getRootStoreItem("keyring")?.[key];
+const getKeyringItem = (key) => getRootStoreItem("keyring")?.[key] ?? {};
 const setKeyringItem = (key, value) =>
   setRootStoreItem("keyring", { [`${key}`]: value });
 const removeKeyringItem = (key) =>

--- a/src/util/localStorage.js
+++ b/src/util/localStorage.js
@@ -1,33 +1,35 @@
-import { constants } from "./helpers";
 import omit from "lodash/omit";
+const WALLET_ID_STORAGE_KEY = "gridplus_web_wallet_id";
+const WALLET_PASSWORD_STORAGE_KEY = "gridplus_web_wallet_password";
+const ROOT_STORE = process.env.REACT_APP_ROOT_STORE || "gridplus";
 
 const getItem = (key) => JSON.parse(window.localStorage.getItem(key));
 const setItem = (key, value) =>
   window.localStorage.setItem(key, JSON.stringify(value));
 const removeItem = (key) => window.localStorage.removeItem(key);
 
-const getRootStore = () => getItem(constants.ROOT_STORE) ?? {};
+const getRootStore = () => getItem(ROOT_STORE) ?? {};
 const setRootStore = (value) =>
   window.localStorage.setItem(
-    constants.ROOT_STORE,
+    ROOT_STORE,
     JSON.stringify({ ...getRootStore(), ...value })
   );
-const removeRootStore = () => removeItem(constants.ROOT_STORE);
+const removeRootStore = () => removeItem(ROOT_STORE);
 
-const getRootStoreItem = (key) => getItem(constants.ROOT_STORE)?.[key] ?? {};
+const getRootStoreItem = (key) => getItem(ROOT_STORE)?.[key] ?? {};
 const setRootStoreItem = (key, value) =>
   window.localStorage.setItem(
-    constants.ROOT_STORE,
+    ROOT_STORE,
     JSON.stringify({ ...getRootStore(), [`${key}`]: value })
   );
 const removeRootStoreItem = (key) =>
   window.localStorage.setItem(
-    constants.ROOT_STORE,
+    ROOT_STORE,
     JSON.stringify(omit(getRootStore(), key))
   );
 
 const getSettings = () => getRootStoreItem("settings");
-const setSettings = (value) => setRootStoreItem("settings", value)
+const setSettings = (value) => setRootStoreItem("settings", value);
 
 const getKeyring = () => getRootStoreItem("keyring");
 
@@ -37,15 +39,14 @@ const setKeyringItem = (key, value) =>
 const removeKeyringItem = (key) =>
   setRootStoreItem("keyring", omit(getKeyring(), key));
 
-const getWalletId = () => getItem(constants.WALLET_ID_STORAGE_KEY);
-const setWalletId = (value) => setItem(constants.WALLET_ID_STORAGE_KEY, value);
-const removeWalletId = () => removeItem(constants.WALLET_ID_STORAGE_KEY);
+const getWalletId = () => getItem(WALLET_ID_STORAGE_KEY);
+const setWalletId = (value) => setItem(WALLET_ID_STORAGE_KEY, value);
+const removeWalletId = () => removeItem(WALLET_ID_STORAGE_KEY);
 
-const getWalletPassword = () => getItem(constants.WALLET_PASSWORD_STORAGE_KEY);
+const getWalletPassword = () => getItem(WALLET_PASSWORD_STORAGE_KEY);
 const setWalletPassword = (value) =>
-  setItem(constants.WALLET_PASSWORD_STORAGE_KEY, value);
-const removeWalletPassword = () =>
-  removeItem(constants.WALLET_PASSWORD_STORAGE_KEY);
+  setItem(WALLET_PASSWORD_STORAGE_KEY, value);
+const removeWalletPassword = () => removeItem(WALLET_PASSWORD_STORAGE_KEY);
 
 export default {
   getItem,

--- a/src/util/localStorage.js
+++ b/src/util/localStorage.js
@@ -1,0 +1,72 @@
+import { constants } from "./helpers";
+import omit from "lodash/omit";
+
+const getItem = (key) => JSON.parse(window.localStorage.getItem(key));
+const setItem = (key, value) =>
+  window.localStorage.setItem(key, JSON.stringify(value));
+const removeItem = (key) => window.localStorage.removeItem(key);
+
+const getRootStore = () => getItem(constants.ROOT_STORE) ?? {};
+const setRootStore = (value) =>
+  window.localStorage.setItem(
+    constants.ROOT_STORE,
+    JSON.stringify({ ...getRootStore(), ...value })
+  );
+const removeRootStore = () => removeItem(constants.ROOT_STORE);
+
+const getRootStoreItem = (key) => getItem(constants.ROOT_STORE)?.[key] ?? {};
+const setRootStoreItem = (key, value) =>
+  window.localStorage.setItem(
+    constants.ROOT_STORE,
+    JSON.stringify({ ...getRootStore(), [`${key}`]: value })
+  );
+const removeRootStoreItem = (key) =>
+  window.localStorage.setItem(
+    constants.ROOT_STORE,
+    JSON.stringify(omit(getRootStore(), key))
+  );
+
+const getSettings = () => getRootStoreItem("settings");
+const setSettings = (value) => setRootStoreItem("settings", value)
+
+const getKeyring = () => getRootStoreItem("keyring");
+
+const getKeyringItem = (key) => getRootStoreItem("keyring")?.[key];
+const setKeyringItem = (key, value) =>
+  setRootStoreItem("keyring", { [`${key}`]: value });
+const removeKeyringItem = (key) =>
+  setRootStoreItem("keyring", omit(getKeyring(), key));
+
+const getWalletId = () => getItem(constants.WALLET_ID_STORAGE_KEY);
+const setWalletId = (value) => setItem(constants.WALLET_ID_STORAGE_KEY, value);
+const removeWalletId = () => removeItem(constants.WALLET_ID_STORAGE_KEY);
+
+const getWalletPassword = () => getItem(constants.WALLET_PASSWORD_STORAGE_KEY);
+const setWalletPassword = (value) =>
+  setItem(constants.WALLET_PASSWORD_STORAGE_KEY, value);
+const removeWalletPassword = () =>
+  removeItem(constants.WALLET_PASSWORD_STORAGE_KEY);
+
+export default {
+  getItem,
+  setItem,
+  removeItem,
+  getRootStore,
+  setRootStore,
+  removeRootStore,
+  getRootStoreItem,
+  setRootStoreItem,
+  removeRootStoreItem,
+  getSettings,
+  setSettings,
+  getWalletId,
+  setWalletId,
+  removeWalletId,
+  getWalletPassword,
+  setWalletPassword,
+  removeWalletPassword,
+  getKeyring,
+  getKeyringItem,
+  setKeyringItem,
+  removeKeyringItem,
+};

--- a/src/util/localStorage.js
+++ b/src/util/localStorage.js
@@ -1,7 +1,10 @@
 import omit from "lodash/omit";
-const WALLET_ID_STORAGE_KEY = "gridplus_web_wallet_id";
-const WALLET_PASSWORD_STORAGE_KEY = "gridplus_web_wallet_password";
+
+const LOGIN_ID_STORAGE_KEY = "gridplus_web_wallet_id";
+const LOGIN_PASSWORD_STORAGE_KEY = "gridplus_web_wallet_password";
 const ROOT_STORE = process.env.REACT_APP_ROOT_STORE || "gridplus";
+
+// #region -- Generic Local Storage Functions
 
 const getItem = (key) => JSON.parse(window.localStorage.getItem(key));
 const setItem = (key, value) =>
@@ -28,8 +31,16 @@ const removeRootStoreItem = (key) =>
     JSON.stringify(omit(getRootStore(), key))
   );
 
+// #endregion
+
+// #region -- Settings Functions
+
 const getSettings = () => getRootStoreItem("settings");
 const setSettings = (value) => setRootStoreItem("settings", value);
+
+// #endregion
+
+// #region -- Keyring Functions
 
 const getKeyring = () => getRootStoreItem("keyring");
 
@@ -39,14 +50,32 @@ const setKeyringItem = (key, value) =>
 const removeKeyringItem = (key) =>
   setRootStoreItem("keyring", omit(getKeyring(), key));
 
-const getWalletId = () => getItem(WALLET_ID_STORAGE_KEY);
-const setWalletId = (value) => setItem(WALLET_ID_STORAGE_KEY, value);
-const removeWalletId = () => removeItem(WALLET_ID_STORAGE_KEY);
+// #endregion
 
-const getWalletPassword = () => getItem(WALLET_PASSWORD_STORAGE_KEY);
-const setWalletPassword = (value) =>
-  setItem(WALLET_PASSWORD_STORAGE_KEY, value);
-const removeWalletPassword = () => removeItem(WALLET_PASSWORD_STORAGE_KEY);
+// #region -- Login Functions
+
+const getLoginId = () => getItem(LOGIN_ID_STORAGE_KEY);
+const setLoginId = (value) => setItem(LOGIN_ID_STORAGE_KEY, value);
+const removeLoginId = () => removeItem(LOGIN_ID_STORAGE_KEY);
+
+const getLoginPassword = () => getItem(LOGIN_PASSWORD_STORAGE_KEY);
+const setLoginPassword = (value) => setItem(LOGIN_PASSWORD_STORAGE_KEY, value);
+const removeLoginPassword = () => removeItem(LOGIN_PASSWORD_STORAGE_KEY);
+
+const getLogin = () => ({
+  deviceID: getLoginId(),
+  password: getLoginPassword(),
+});
+const setLogin = ({ deviceID, password }) => {
+  setLoginId(deviceID);
+  setLoginPassword(password);
+};
+const removeLogin = () => {
+  removeLoginId();
+  removeLoginPassword();
+};
+
+// #endregion
 
 export default {
   getItem,
@@ -60,14 +89,17 @@ export default {
   removeRootStoreItem,
   getSettings,
   setSettings,
-  getWalletId,
-  setWalletId,
-  removeWalletId,
-  getWalletPassword,
-  setWalletPassword,
-  removeWalletPassword,
+  getLoginId,
+  setLoginId,
+  removeLoginId,
+  getLoginPassword,
+  setLoginPassword,
+  removeLoginPassword,
   getKeyring,
   getKeyringItem,
   setKeyringItem,
   removeKeyringItem,
+  getLogin,
+  setLogin,
+  removeLogin,
 };

--- a/src/util/storageSession.js
+++ b/src/util/storageSession.js
@@ -1,8 +1,9 @@
-import { constants } from './helpers';
+import localStorage from './localStorage';
+
 class StorageSession {
   constructor(device_id, pass) {
     this.data = null;
-    this.store = JSON.parse(window.localStorage.getItem(constants.ROOT_STORE) || '{}');
+    this.store = localStorage.getRootStore();
   }
 
   isObject(o) {
@@ -49,7 +50,7 @@ class StorageSession {
       this.updateBranch(data, this.store[deviceID][wallet_uid], k);
     })
     // Update the store itself
-    window.localStorage.setItem(constants.ROOT_STORE, JSON.stringify(this.store));
+    localStorage.setRootStore(this.store);
   }
 
   getWalletData(deviceID, wallet_uid) {


### PR DESCRIPTION
While debugging this, we noticed a few issues with unexpected behavior with localStorage. It was hard to reason about data manipulation because the keychain data was saved deeply nested: 

```
{ gridplus: 
	{ settings: 
		{ keychainLogins: 
			{ [keychain login name]: 
				{ 
					data   <== data was saved here
				} 
			} 
		} 
	}
}
```
And we didn't have any helper functions to update that data easily without error. 

To make it a bit easier, I moved where that data is stored up one level to the `gridplus` key, and added helper functions to ensure we can easily update that data.

Along with the helpers, I went ahead and pulled all the window.localStorage calls into a single file with a single output, so all access is easy and consistent. It puts all the calls off of an import of an object called `localStorage` that you can use to get any item out or store any item; with those helpers for common behaviors (e.g. saving keychain data or fetching settings data). 

I also avoid completely overwriting the state in localStorage whenever possible. It was causing issues for this ticket and would've probably caused more in the future. 

It's a bigger PR than I was originally intending, but I think it's a worthwhile update to how that data is managed.

Fixes #186 