### PR TITLE
Fix Address Tags Pagination

### DIFF
--- a/src/components/kvFiles.js
+++ b/src/components/kvFiles.js
@@ -260,7 +260,6 @@ class KVFiles extends React.Component {
                 position: ["bottomCenter"],
                 pageSize: RECORDS_PER_PAGE,
                 defaultCurrent: displayPage,
-                showQuickJumper: true,
               }}
             >
               <Table.Column title="Name" dataIndex="val" key="val"

--- a/src/components/kvFiles.js
+++ b/src/components/kvFiles.js
@@ -2,8 +2,9 @@ import React from 'react'
 import 'antd/dist/antd.dark.css'
 import { Alert, Button, Card, Checkbox, Col, Input, Row, Spin, Table } from 'antd'
 import { allChecks } from '../util/sendChecks';
-import { LoadingOutlined } from '@ant-design/icons';
-import uniqBy from "lodash/uniqBy"
+import { LoadingOutlined, SyncOutlined, PlusOutlined } from '@ant-design/icons';
+import unionBy from "lodash/unionBy"
+import differenceBy from "lodash/differenceBy"
 import { PageContent } from './index'
 const ADDRESS_RECORD_TYPE = 0
 const RECORDS_PER_PAGE = 10;
@@ -81,6 +82,16 @@ class KVFiles extends React.Component {
     return selected;
   }
 
+  addToRecordsInState (recordsToAdd) {
+    // Combines passed in array of records and records in state by comparing ids
+    this.setState({ records: unionBy(this.state.records, recordsToAdd, "id") });
+  }
+
+  removeFromRecordsInState (recordsToRemove) {
+    // Removes passed in array of records from records in state by comparing ids
+    this.setState({ records: differenceBy(this.state.records, recordsToRemove, "id") });
+  }
+
   fetchRecords (page = 0, retries = 1) {
     const opts = {
       start: page * RECORDS_PER_PAGE,
@@ -88,8 +99,7 @@ class KVFiles extends React.Component {
     }
     // Sanity check to make sure we didn't overrun the current page
     if (opts.start > this.state.records.length) {
-      this.setState({ error: 'Mismatch fetching records.' })
-      return;
+      return this.setState({ error: 'Mismatch fetching records.' })
     }
     this.setState({ loading: true })
     this.props.session.client.getKvRecords(opts, (err, res) => {
@@ -101,8 +111,7 @@ class KVFiles extends React.Component {
           return this.fetchRecords(page, retries - 1)
         }
       } else if (res) {
-        // Combines new records with current records and de-duplicates them by record id
-        this.setState({ records: uniqBy([...this.state.records, ...res.records], (r) => r.id) })
+        this.addToRecordsInState(res.records)
         const recordsToFetch = res.total - this.state.records.length
         if (recordsToFetch > 0) {
           return this.fetchRecords(page + 1)
@@ -140,38 +149,25 @@ class KVFiles extends React.Component {
     }
     this.setState({ loading: true })
     this.props.session.client.addKvRecords(opts, (err) => {
-      if (err) {
-        this.setState({ error: err, loading: false })
-        return
-      }
+      if (err) return this.setState({ error: err, loading: false })
+      this.addToRecordsInState([this.state.recordToAdd])
       this.setState({ 
-        recordToAdd: { key: '' , val: '' }
+        recordToAdd: { key: '', val: '' },
+        error: null,
+        loading: false
       })
-      this.fetchRecords()
     })
   }
 
-  removeSelected() {
-    const ids = [];
-    const remainingRecords = [];
-    this.state.records.forEach((record) => {
-      if (record.isChecked) {
-        ids.push(record.id)
-      } else {
-        remainingRecords.push(record);
-      }
-    })
-    if (ids.length === 0)
-      return;
+  removeSelected () {
+    const recordsToRemove = this.state.records.filter((r) => r.isChecked);
+    const ids = recordsToRemove.map((r) => r.id);
+    if (ids.length === 0) return
     this.setState({ loading: true })
     this.props.session.client.removeKvRecords({ ids }, (err) => {
-      if (err) {
-        this.setState({ error: err, loading: false})
-        return
-      }
-      this.setState({ records: remainingRecords}, () => {
-        this.fetchRecords();
-      })
+      if (err) return this.setState({ error: err, loading: false })
+      this.removeFromRecordsInState(recordsToRemove)
+      this.setState({ error: null, loading: false })
     })
   }
 
@@ -220,7 +216,7 @@ class KVFiles extends React.Component {
 
   renderAddCard() {
     const extraLink = (
-      <Button type="link" onClick={() => { this.setState({ isAdding: false })}}>View Addresses</Button>
+      <Button type="ghost" onClick={() => { this.setState({ isAdding: false }) }}>View Addresses</Button>
     )
     return (
       <Card title={'Save Address Tag'} extra={extraLink} bordered={true}>
@@ -251,11 +247,11 @@ class KVFiles extends React.Component {
 
   renderDisplayCard() {
     const displayPage = this.state.page + 1;
-    const extraLink = (
-      <Button type="link" onClick={() => { this.setState({ isAdding: true })}}>Add Addresses</Button>
-    )
+    const extra = [
+      <Button type="link" icon={<SyncOutlined />} disabled={this.state.loading} onClick={() => { this.fetchRecords() }}>Sync</Button>,
+      <Button type="ghost" icon={<PlusOutlined />} disabled={this.state.loading} onClick={() => { this.setState({ isAdding: true }) }}>Add</Button>];
     return (
-      <Card title={'Saved Addresses'} extra={extraLink} bordered={true}>
+      <Card title={'Saved Addresses'} extra={extra} bordered={true}>
         {this.state.loading ? this.renderLoading() : (
           <div>
              <Table


### PR DESCRIPTION
The `fetchRecords` function now fetches all addresses and stores them in the `records` array. 

Modifying the list via adding or removing items, refetches the entire list of addresses. 

To avoid duplicate records, the result of combining the current and new records is run through a filter function from `lodash` called `uniqBy` that in this case uses a record's `id` to make sure there aren't any dupes in the record list. This assumes that `id` values are unique in the system.

Fixes #200