### PR TITLE
Disables size changer for large datasets

### DIFF
--- a/src/components/kvFiles.js
+++ b/src/components/kvFiles.js
@@ -279,6 +279,7 @@ class KVFiles extends React.Component {
                 position: ["bottomCenter"],
                 pageSize: RECORDS_PER_PAGE,
                 defaultCurrent: displayPage,
+                showSizeChanger: false,
               }}
             >
               <Table.Column


### PR DESCRIPTION
I didn't realize that by default Ant Design pagination adds a page size changer after 50 items are in the data set....  This PR disables it entirely. 

Fixes [this issue from discord](https://discord.com/channels/727934140980396063/898337875148554292/930707776139837450)