### PR TITLE
Adds Caching for Address & Contract data via AppContext

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import 'antd/dist/antd.dark.css'
 import { Main } from './components'
-
+import { AppContextProvider } from "./store/AppContext";
 
 function App() {
   return (
     <div className="App">
-      <Main/>
+      <AppContextProvider>
+        <Main />
+      </AppContextProvider>
     </div>
   );
 }

--- a/src/components/AddressTable.tsx
+++ b/src/components/AddressTable.tsx
@@ -14,16 +14,16 @@ const { ADDRESSES_PER_PAGE } = constants;
  *
  * @param `addresses` - the list of key-value records to display
  * @param `isLoading` - the table displays a loading spinner when true
- * @param `removeSelected` - callback that lets the parent component remove a selected record
+ * @param `removeAddresses` - callback that lets the parent component remove a selected record
  */
 export const AddressTable = ({
   addresses,
   isLoading,
-  removeSelected,
+  removeAddresses,
 }: {
   addresses: Record[];
   isLoading: boolean;
-  removeSelected: (selectedAddresses: Record[]) => void;
+  removeAddresses: (selectedAddresses: Record[]) => void;
 }) => {
   const [input, setInput] = useState("");
   const [filteredAddresses, setFilteredAddresses] = useState([]);
@@ -72,7 +72,7 @@ export const AddressTable = ({
           danger
           type="text"
           disabled={selectedAddresses.length === 0}
-          onClick={()=>removeSelected(selectedAddresses)}
+          onClick={() => removeAddresses(selectedAddresses)}
           style={{ marginLeft: "1em" }}
         >
           Remove Selected

--- a/src/components/AddressTagsPage.tsx
+++ b/src/components/AddressTagsPage.tsx
@@ -15,6 +15,7 @@ const AddressTagsPage = () => {
     isLoading,
     addresses,
     removeAddresses,
+    resetAddressesInState,
     error,
     retryFunction,
   } = useAddresses();
@@ -24,7 +25,7 @@ const AddressTagsPage = () => {
     if (isEmpty(addresses)) {
       fetchAddresses();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchAddresses]);
 
   const extra = [
@@ -33,7 +34,10 @@ const AddressTagsPage = () => {
       type="link"
       icon={<SyncOutlined />}
       disabled={isLoading}
-      onClick={fetchAddresses}
+      onClick={() => {
+        resetAddressesInState();
+        fetchAddresses();
+      }}
     >
       Sync
     </Button>,

--- a/src/components/AddressTagsPage.tsx
+++ b/src/components/AddressTagsPage.tsx
@@ -22,7 +22,7 @@ const AddressTagsPage = () => {
 
   // Fetch and Cache Addresses
   useEffect(() => {
-    if (isEmpty(addresses)) {
+    if (isEmpty(addresses) && !isLoading) {
       fetchAddresses();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/AddressTagsPage.tsx
+++ b/src/components/AddressTagsPage.tsx
@@ -1,89 +1,31 @@
 import { SyncOutlined } from "@ant-design/icons";
-import { Alert, Button, Card } from "antd";
+import { Button, Card } from "antd";
 import "antd/dist/antd.dark.css";
-import React, { useCallback, useEffect, useState } from "react";
-import { useRecords } from "../hooks/useRecords";
-import SDKSession from "../sdk/sdkSession";
-import { constants } from "../util/helpers";
+import React, { useEffect } from "react";
+import { useAddresses } from "../hooks/useAddresses";
 import { AddAddressesButton } from "./AddAddressesButton";
 import { AddressTable } from "./AddressTable";
 import { PageContent } from "./index";
-import { Record } from "../types/records";
-const { ADDRESSES_PER_PAGE } = constants;
+import isEmpty from "lodash/isEmpty";
+import { ErrorAlert } from "./ErrorAlert";
 
-const AddressTagsPage = ({
-  isMobile,
-  session,
-}: {
-  isMobile: () => boolean;
-  session: SDKSession;
-}) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState("");
-  const [retryFunction, setRetryFunction] = useState(null);
-  const [addresses, addAddresses, removeAddresses] = useRecords([]);
+const AddressTagsPage = () => {
+  const {
+    fetchAddresses,
+    isLoading,
+    addresses,
+    removeAddresses,
+    error,
+    retryFunction,
+  } = useAddresses();
 
-  const fetchRecords = useCallback(
-    async (fetched = 0, retries = 1) => {
-      setIsLoading(true);
-      session
-        .client
-        .getKvRecords({
-          start: fetched,
-          n: ADDRESSES_PER_PAGE,
-        })
-        .then((res: any) => {
-          addAddresses(res.records);
-          const totalFetched = res.fetched + fetched;
-          const remainingToFetch = res.total - totalFetched;
-          if (remainingToFetch > 0) {
-            fetchRecords(fetched + res.fetched);
-          } else {
-            setError(null);
-            setIsLoading(false);
-          }
-        })
-        .catch((err) => {
-          if (retries > 0) {
-            setError(null);
-            fetchRecords(fetched, retries - 1);
-          } else {
-            setError(err);
-            setIsLoading(false);
-            setRetryFunction(fetchRecords);
-          }
-        });
-    },
-    [addAddresses, session.client]
-  );
-
+  // Fetch and Cache Addresses
   useEffect(() => {
-    fetchRecords();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const removeSelected = (selectedAddresses: Record[]) => {
-    const ids = selectedAddresses.map((r) => parseInt(r.id));
-    if (ids.length === 0) return;
-    setIsLoading(true);
-    session
-      .client
-      .removeKvRecords({ ids, type: undefined })
-      .then(() => {
-        removeAddresses(selectedAddresses);
-        setError(null);
-        setIsLoading(false);
-      })
-      .catch((err) => {
-        setError(err);
-        setIsLoading(false);
-        setRetryFunction(removeSelected);
-      });
-  };
-
-  const onAddAddresses = () => {
-    fetchRecords()
-  }
+    if (isEmpty(addresses)) {
+      fetchAddresses();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchAddresses]);
 
   const extra = [
     <Button
@@ -91,49 +33,18 @@ const AddressTagsPage = ({
       type="link"
       icon={<SyncOutlined />}
       disabled={isLoading}
-      onClick={fetchRecords}
+      onClick={fetchAddresses}
     >
       Sync
     </Button>,
-    <AddAddressesButton
-      key="add-addresses-button"
-      records={addresses}
-      session={session}
-      onAddAddresses={onAddAddresses}
-    />,
+    <AddAddressesButton key="add-addresses-button" />,
   ];
 
-  const ErrorAlert = () =>
-    error && (
-      <Alert
-        message="Error"
-        description={error}
-        action={
-          retryFunction ? (
-            <Button
-              //@ts-expect-error
-              type="danger"
-              onClick={() => {
-                retryFunction();
-                setRetryFunction(null);
-                setError(null);
-              }}
-            >
-              Retry
-            </Button>
-          ) : null
-        }
-        type="error"
-        closable
-        onClose={() => setError(null)}
-      />
-    );
-
   return (
-    <PageContent isMobile={isMobile}>
-      <ErrorAlert />
+    <PageContent>
+      <ErrorAlert error={error} retryFunction={retryFunction} />
       <Card title={"Saved Addresses"} extra={extra} bordered={true}>
-        <AddressTable {...{ addresses, isLoading, removeSelected }} />
+        <AddressTable {...{ addresses, isLoading, removeAddresses }} />
       </Card>
     </PageContent>
   );

--- a/src/components/ContractCardList.tsx
+++ b/src/components/ContractCardList.tsx
@@ -1,4 +1,5 @@
-import { Input, Pagination, Space } from "antd";
+import { SyncOutlined } from "@ant-design/icons";
+import { Button, Input, Pagination, Space } from "antd";
 import fuzzysort from "fuzzysort";
 import chunk from "lodash/chunk";
 import React, { useCallback, useEffect, useState } from "react";
@@ -9,7 +10,12 @@ import { SelectNetwork } from "./SelectNetwork";
 const pageSize = constants.CONTRACT_PAGE_SIZE;
 
 export function ContractCardList() {
-  const { contractPacks } = useContracts();
+  const {
+    contractPacks,
+    isLoading,
+    fetchContractPacks,
+    resetContractPacksInState,
+  } = useContracts();
   const [filteredPacks, setFilteredPacks] = useState([]);
   const [paginatedPacks, setPaginatedPacks] = useState([]);
   const [page, setPage] = useState(1);
@@ -67,22 +73,33 @@ export function ContractCardList() {
           width: "100%",
         }}
       >
-        <Input.Group compact>
+        <Input.Group
+          compact
+          style={{
+            display: "flex",
+            justifyContent: "flex-start",
+            flexWrap: "wrap",
+            width: "100%",
+          }}
+        >
           <SelectNetwork setNetwork={setNetwork} />
           <Input
             placeholder="Filter"
             onChange={onChange}
-            style={{ maxWidth: "50%" }}
+            style={{ maxWidth: "80%" }}
           />
-          <Pagination
-            style={{ marginLeft: "10px" }}
-            current={page}
-            defaultCurrent={1}
-            pageSize={pageSize}
-            defaultPageSize={pageSize}
-            onChange={setPage}
-            total={filteredPacks?.length}
-          />
+          <Button
+            key="sync-button"
+            type="link"
+            icon={<SyncOutlined />}
+            disabled={isLoading}
+            onClick={() => {
+              resetContractPacksInState();
+              fetchContractPacks();
+            }}
+          >
+            Sync
+          </Button>
         </Input.Group>
 
         <div
@@ -107,6 +124,22 @@ export function ContractCardList() {
               </p>
             </div>
           )}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            width: "100%",
+          }}
+        >
+          <Pagination
+            style={{ margin: "20px auto 0 auto" }}
+            current={page}
+            defaultCurrent={1}
+            pageSize={pageSize}
+            defaultPageSize={pageSize}
+            onChange={setPage}
+            total={filteredPacks?.length}
+          />
         </div>
       </Space>
     </div>

--- a/src/components/ContractCardList.tsx
+++ b/src/components/ContractCardList.tsx
@@ -2,42 +2,31 @@ import { Input, Pagination, Space } from "antd";
 import fuzzysort from "fuzzysort";
 import chunk from "lodash/chunk";
 import React, { useCallback, useEffect, useState } from "react";
+import { useContracts } from "../hooks/useContracts";
 import { constants } from "../util/helpers";
 import { ContractCard } from "./ContractCard";
 import { SelectNetwork } from "./SelectNetwork";
 const pageSize = constants.CONTRACT_PAGE_SIZE;
 
-export function ContractCardList({ session }) {
-  const [packs, setPacks] = useState([]);
+export function ContractCardList() {
+  const { contractPacks } = useContracts();
   const [filteredPacks, setFilteredPacks] = useState([]);
   const [paginatedPacks, setPaginatedPacks] = useState([]);
   const [page, setPage] = useState(1);
   const [network, setNetwork] = useState(constants.DEFAULT_CONTRACT_NETWORK);
 
   const filterPacksByNetwork = useCallback(
-    (packs) => packs.filter((pack) => pack?.network === network),
+    (packs) => packs.filter((pack) => pack?.metadata.network === network),
     [network]
   );
-
-  const loadPackIndex = useCallback(() => {
-    fetch(`${constants.ABI_PACK_URL}/`)
-      .then((response) => response.json())
-      .then((resp) => {
-        setPacks(resp);
-      });
-  }, []);
-
-  useEffect(() => {
-    loadPackIndex();
-  }, [loadPackIndex]);
 
   useEffect(() => {
     setPage(1);
   }, [filteredPacks]);
 
   useEffect(() => {
-    setFilteredPacks(filterPacksByNetwork(packs));
-  }, [packs, network, filterPacksByNetwork]);
+    setFilteredPacks(filterPacksByNetwork(contractPacks));
+  }, [network, filterPacksByNetwork, contractPacks]);
 
   useEffect(() => {
     const pageZeroIndexed = page - 1;
@@ -47,14 +36,16 @@ export function ContractCardList({ session }) {
 
   const fuzzyFilterPacksByName = (value) =>
     fuzzysort
-      .go(value, packs, {
-        key: "name",
+      .go(value, contractPacks, {
+        key: ["metadata", "name"],
       })
       .map((x) => x.obj);
 
   const onChange = ({ target: { value } }) => {
     setPage(1);
-    const fuzzyFilteredPacks = value ? fuzzyFilterPacksByName(value) : packs;
+    const fuzzyFilteredPacks = value
+      ? fuzzyFilterPacksByName(value)
+      : contractPacks;
     setFilteredPacks(filterPacksByNetwork(fuzzyFilteredPacks));
   };
 
@@ -104,7 +95,7 @@ export function ContractCardList({ session }) {
         >
           {paginatedPacks.length ? (
             paginatedPacks.map((pack) => (
-              <ContractCard pack={pack} session={session} key={pack.name} />
+              <ContractCard pack={pack} key={pack.metadata.name} />
             ))
           ) : (
             <div style={{ marginTop: "20px" }}>

--- a/src/components/ContractTable.tsx
+++ b/src/components/ContractTable.tsx
@@ -4,21 +4,29 @@ import fuzzysort from "fuzzysort";
 import intersectionBy from "lodash/intersectionBy";
 import React, { useCallback, useEffect, useState } from "react";
 import { useContracts } from "../hooks/useContracts";
+import { ContractRecord } from "../types/contracts";
 import { constants } from "../util/helpers";
 const { CONTRACTS_PER_PAGE } = constants;
 
 /**
  * `ContractTable` is a table of ABI contract data with some management features to
  * make it easier to manage a large amount of contracts.
- *
- * @param `session` - the active SDK session
  */
 export const ContractTable = () => {
   const [input, setInput] = useState("");
-  const { isLoading, contracts, fetchContracts, removeContracts } =
-    useContracts();
-  const [filteredContracts, setFilteredContracts] = useState([]);
-  const [selectedContracts, setSelectedContracts] = useState([]);
+  const {
+    isLoading,
+    contracts,
+    fetchContracts,
+    removeContracts,
+    resetContractsInState,
+  } = useContracts();
+  const [filteredContracts, setFilteredContracts] = useState<ContractRecord[]>(
+    []
+  );
+  const [selectedContracts, setSelectedContracts] = useState<ContractRecord[]>(
+    []
+  );
 
   useEffect(() => {
     if (contracts.length === 0) {
@@ -80,7 +88,10 @@ export const ContractTable = () => {
           type="link"
           icon={<SyncOutlined />}
           disabled={isLoading}
-          onClick={fetchContracts}
+          onClick={() => {
+            resetContractsInState();
+            fetchContracts();
+          }}
         >
           Sync
         </Button>
@@ -88,7 +99,7 @@ export const ContractTable = () => {
       <Table
         dataSource={filteredContracts}
         tableLayout="fixed"
-        rowKey={(r) => r.header.name}
+        rowKey={(r) => r.id}
         loading={{
           spinning: isLoading,
           tip: "Loading...",
@@ -104,9 +115,7 @@ export const ContractTable = () => {
           type: "checkbox",
           onSelect: handleOnSelect,
           onSelectAll: handleOnSelectAll,
-          selectedRowKeys: selectedContracts.map(
-            (contract) => contract?.header?.name
-          ),
+          selectedRowKeys: selectedContracts.map((contract) => contract.id),
         }}
         expandable={{
           expandedRowRender: (record) => (
@@ -127,13 +136,17 @@ export const ContractTable = () => {
           title="Function Name"
           dataIndex={["header", "name"]}
           defaultSortOrder="ascend"
-          sorter={(a: any, b: any) => a.header.name.localeCompare(b.val)}
+          sorter={(a: ContractRecord, b: ContractRecord) =>
+            a.header.name.localeCompare(b.val)
+          }
         />
         <Table.Column
           title="Identifier"
           dataIndex={["header", "sig"]}
           defaultSortOrder="ascend"
-          sorter={(a: any, b: any) => a.header.sig.localeCompare(b.val)}
+          sorter={(a: ContractRecord, b: ContractRecord) =>
+            a.header.sig.localeCompare(b.val)
+          }
         />
       </Table>
     </div>

--- a/src/components/ContractTable.tsx
+++ b/src/components/ContractTable.tsx
@@ -21,7 +21,9 @@ export const ContractTable = () => {
   const [selectedContracts, setSelectedContracts] = useState([]);
 
   useEffect(() => {
-    if (contracts.length === 0) fetchContracts();
+    if (contracts.length === 0) {
+      fetchContracts();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/ErrorAlert.tsx
+++ b/src/components/ErrorAlert.tsx
@@ -1,0 +1,24 @@
+import { Alert, Button } from "antd";
+import React from "react";
+
+export const ErrorAlert = ({ error, retryFunction }) => {
+  return error ? (
+    <Alert
+      message="Error"
+      description={error}
+      type="error"
+      closable
+      action={
+        <Button
+          //@ts-expect-error
+          type="danger"
+          onClick={() => {
+            retryFunction && retryFunction();
+          }}
+        >
+          Retry
+        </Button>
+      }
+    />
+  ) : null;
+};

--- a/src/components/SearchCard.tsx
+++ b/src/components/SearchCard.tsx
@@ -1,13 +1,15 @@
 import { DownloadOutlined } from "@ant-design/icons";
 import { Button, Card, Input, Result } from "antd";
 import throttle from "lodash/throttle";
-import React, { useMemo, useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
+import { AppContext } from "../store/AppContext";
 import { constants } from "../util/helpers";
 import { SelectNetwork } from "./SelectNetwork";
 const defaultNetwork =
   constants.CONTRACT_NETWORKS[constants.DEFAULT_CONTRACT_NETWORK];
 
-export const SearchCard = ({ session }) => {
+export const SearchCard = () => {
+  const { session } = useContext(AppContext)
   const [loading, setLoading] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [success, setSuccess] = useState(false);

--- a/src/components/SearchCard.tsx
+++ b/src/components/SearchCard.tsx
@@ -4,17 +4,19 @@ import throttle from "lodash/throttle";
 import React, { useContext, useMemo, useState } from "react";
 import { useContracts } from "../hooks/useContracts";
 import { AppContext } from "../store/AppContext";
+import { ContractDefinition } from "../types/contracts";
+import { transformContractDefinitionToContractRecord } from "../util/contracts";
 import { constants } from "../util/helpers";
 import { SelectNetwork } from "./SelectNetwork";
 const defaultNetwork =
   constants.CONTRACT_NETWORKS[constants.DEFAULT_CONTRACT_NETWORK];
 
 export const SearchCard = () => {
-  const { session } = useContext(AppContext)
+  const { session } = useContext(AppContext);
   const [installing, setInstalling] = useState(false);
   const [success, setSuccess] = useState(false);
   const [contract, setContract] = useState("");
-  const [defs, setDefs] = useState([]);
+  const [defs, setDefs] = useState<ContractDefinition[]>([]);
   const [network, setNetwork] = useState(constants.DEFAULT_CONTRACT_NETWORK);
   const { error, setError, addContracts, isLoading, setIsLoading } =
     useContracts();
@@ -42,18 +44,18 @@ export const SearchCard = () => {
     } else {
       const { label, baseUrl, apiRoute } = getNetwork();
       fetch(`${baseUrl}/${apiRoute}${input}`)
-        .then((response) => response.json())
-        .then((resp) => {
+        .then((res) => res.json())
+        .then((res) => {
           // Map confusing error strings to better descriptions
-          if (resp.result === "Contract source code not verified") {
-            resp.result = `Contract source code not published to ${label} or not verified. Cannot determine data.`;
+          if (res.result === "Contract source code not verified") {
+            res.result = `Contract source code not published to ${label} or not verified. Cannot determine data.`;
           }
-          if (resp.status === "0") {
-            setError(resp.result);
+          if (res.status === "0") {
+            setError(res.result);
             resetData();
           } else {
             try {
-              const result = JSON.parse(resp.result);
+              const result = JSON.parse(res.result);
               const defs = session.client.parseAbi("etherscan", result, true);
               setDefs(defs);
               setContract(input);
@@ -79,21 +81,23 @@ export const SearchCard = () => {
     [network]
   );
 
-  function addDefs () {
-      setInstalling(true)
-      setError("")
-    
-      addContracts(defs)
-        .then(() => {
-          setError("")
-          setInstalling(false);
-          setSuccess(true);
-        })
-        .catch((err) => {
-          setError(err);
-          resetData();
-        })
-    }
+  function addDefs() {
+    setInstalling(true);
+    setError("");
+
+    const contracts = defs.map(transformContractDefinitionToContractRecord);
+
+    addContracts(contracts)
+      .then(() => {
+        setError("");
+        setInstalling(false);
+        setSuccess(true);
+      })
+      .catch((err) => {
+        setError(err);
+        resetData();
+      });
+  }
 
   const SuccessAlert = () => (
     <Result

--- a/src/components/__tests__/AddAddressesButton.test.tsx
+++ b/src/components/__tests__/AddAddressesButton.test.tsx
@@ -1,192 +1,236 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { AddAddressesButton } from "../AddAddressesButton";
-
-const mockRecords = [{ key: "", val: "" }];
-const mockSession = { client: { addKvRecords: jest.fn() } };
-const mockAddRecordFunc = mockSession.client.addKvRecords;
+import { getMockSession } from "../../testUtils/getMockSession";
+import { renderMockProvider } from "../../testUtils/MockProvider";
+import {
+  AddAddressesButton,
+  valIsDuplicatedErrorMessage,
+} from "../AddAddressesButton";
 
 const existingAddress = "0xc0c8f96C2fE011cc96770D2e37CfbfeAFB585F0a";
 const newAddress = "0xc0c8f96C2fE011cc96770D2e37CfbfeAFB585F0e";
 const existingName = "testName";
 const newName = "testName2";
 
+const renderAddAddressesButton = (overrides?) =>
+  renderMockProvider({ children: <AddAddressesButton />, ...overrides });
+
 describe("AddAddressesButton", () => {
   it("renders", () => {
-    render(
-      <AddAddressesButton
-        records={mockRecords}
-        session={mockSession}
-        addAddresses={() => {}}
-      />
-    );
+    renderAddAddressesButton();
   });
 
-  it("shows and hides the modal", () => {
-    render(
-      <AddAddressesButton
-        records={mockRecords}
-        session={mockSession}
-        addAddresses={() => {}}
-      />
-    );
+  it("shows and hides the modal", async () => {
+    renderAddAddressesButton();
+
     // shows modal
     const addButton = screen.getByRole("button");
-    fireEvent.click(addButton);
-    expect(screen.getByText("Add Address Tags")).toBeInTheDocument();
+    act(() => {
+      fireEvent.click(addButton);
+    });
+    await waitFor(() =>
+      expect(screen.queryByText("Add Address Tags")).toBeInTheDocument()
+    );
 
     // hides modal
     const closeButton = screen.getByRole("button", { name: "Close" });
-    fireEvent.click(closeButton);
-    expect(screen.queryByText("Add Address Tags")).not.toBeVisible();
+    act(() => {
+      fireEvent.click(closeButton);
+    });
+    await waitFor(() =>
+      expect(screen.queryByText("Add Address Tags")).not.toBeInTheDocument()
+    );
   });
 
   it("adds an address", async () => {
-    render(
-      <AddAddressesButton
-        records={mockRecords}
-        session={mockSession}
-        addAddresses={() => {}}
-      />
-    );
+    const session = getMockSession();
+    renderAddAddressesButton({ session });
     const addButton = screen.getByRole("button");
-    fireEvent.click(addButton);
+
+    act(() => {
+      fireEvent.click(addButton);
+    });
 
     const addressInput = screen.getByTestId("0-address-input");
-    const addAddressesButton = screen.getByRole("button", { name: "Add" });
+    act(() => {
+      fireEvent.change(addressInput, { target: { value: newAddress } });
+    });
+
     const nameInput = screen.getByTestId("0-name-input");
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: newName } });
+    });
 
-    // updates form fields
-    fireEvent.change(addressInput, { target: { value: newAddress } });
-    fireEvent.change(nameInput, { target: { value: newName } });
-    fireEvent.click(addAddressesButton);
+    const addAddressesButton = screen.getByRole("button", { name: "Add" });
+    act(() => {
+      fireEvent.click(addAddressesButton);
+    });
 
-    await waitFor(() => expect(mockAddRecordFunc).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(session.client.addKvRecords).toHaveBeenCalledTimes(1)
+    );
   });
 
   it("cancels adding an address", async () => {
-    render(
-      <AddAddressesButton
-        records={mockRecords}
-        session={mockSession}
-        addAddresses={() => {}}
-      />
-    );
+    renderAddAddressesButton();
     const addButton = screen.getByRole("button");
-    fireEvent.click(addButton);
+    act(() => {
+      fireEvent.click(addButton);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("0-address-input")).toBeInTheDocument()
+    );
 
     const addressInput = screen.getByTestId("0-address-input");
+    act(() => {
+      fireEvent.change(addressInput, { target: { value: newAddress } });
+    });
+
     const nameInput = screen.getByTestId("0-name-input");
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: newName } });
+    });
+
     const cancelButton = screen.getByRole("button", {
       name: "Cancel",
     });
-
-    fireEvent.change(addressInput, { target: { value: newAddress } });
-    fireEvent.change(nameInput, { target: { value: newName } });
-
+    act(() => {
+      fireEvent.click(cancelButton);
+    });
     // Modal should be cancelled and disappear
-    fireEvent.click(cancelButton);
-    expect(screen.queryByText("Add Address Tags")).not.toBeVisible();
-
-    // Input fields should be empty after closing modal
-    fireEvent.click(addButton);
-    const addressAfter = screen.getByTestId("0-address-input");
-    const nameInputAfter = screen.getByTestId("0-address-input");
-    expect(addressAfter).toHaveValue("");
-    expect(nameInputAfter).toHaveValue("");
+    waitFor(() =>
+      expect(screen.queryByText("Add Address Tags")).not.toBeInTheDocument()
+    );
   });
 
   it("adds and removes multiple input field groups", async () => {
-    render(
-      <AddAddressesButton
-        records={mockRecords}
-        session={mockSession}
-        addAddresses={() => {}}
-      />
-    );
+    renderAddAddressesButton();
     const addButton = screen.getByRole("button");
-    fireEvent.click(addButton);
+    act(() => {
+      fireEvent.click(addButton);
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "plus Add Another Address Tag",
+        })
+      ).toBeInTheDocument()
+    );
 
     // Adds a new input field group
     const addAddressButton = screen.getByRole("button", {
       name: "plus Add Another Address Tag",
     });
-    fireEvent.click(addAddressButton);
+    act(() => {
+      fireEvent.click(addAddressButton);
+    });
 
     const oneAddressInput = screen.getByTestId("1-address-input");
-    const oneNameInput = screen.getByTestId("1-name-input");
-
     expect(oneAddressInput).toBeInTheDocument();
+
+    const oneNameInput = screen.getByTestId("1-name-input");
     expect(oneNameInput).toBeInTheDocument();
 
     // Removes an input field group and removes input fields from DOM
     const removeAddressButton = screen.getByRole("button", {
       name: "minus-square",
     });
-    fireEvent.click(removeAddressButton);
+    act(() => {
+      fireEvent.click(removeAddressButton);
+    });
+
     expect(screen.queryByTestId("1-address-input")).not.toBeInTheDocument();
     expect(screen.queryByTestId("1-name-input")).not.toBeInTheDocument();
   });
 
   it("validates addresses", async () => {
-    const records = [{ key: existingAddress, val: existingName }];
-    render(
-      <AddAddressesButton
-        records={records}
-        session={mockSession}
-        addAddresses={() => {}}
-      />
-    );
+    const addresses = [{ key: existingAddress, val: existingName }];
+    renderAddAddressesButton({ addresses });
     const addButton = screen.getByRole("button");
-    fireEvent.click(addButton);
+    act(() => {
+      fireEvent.click(addButton);
+    });
 
-    const addressInput = screen.getByTestId("0-address-input");
-    const addAddressesButton = screen.getByRole("button", { name: "Add" });
+    await waitFor(() =>
+      expect(screen.getByTestId("0-address-input")).toBeInTheDocument()
+    );
+
     const nameInput = screen.getByTestId("0-name-input");
-    fireEvent.change(nameInput, { target: { value: "test" } });
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: "test" } });
+    });
 
     // Address exists at all
-    fireEvent.click(addAddressesButton);
-    await waitFor(() => expect(screen.getAllByRole("alert")).toHaveLength(2));
+    const addAddressesButton = screen.getByRole("button", { name: "Add" });
+    act(() => {
+      fireEvent.click(addAddressesButton);
+    });
+    await waitFor(() => expect(screen.getAllByRole("alert")).toHaveLength(1));
 
     // Address matches an address that already exists in the system
-    fireEvent.change(addressInput, { target: { value: existingAddress } });
-    fireEvent.click(addAddressesButton);
-    await waitFor(() => expect(screen.getAllByRole("alert")).toHaveLength(2));
+    const addressInput = screen.getByTestId("0-address-input");
+    act(() => {
+      fireEvent.change(addressInput, { target: { value: existingAddress } });
+    });
+
+    act(() => {
+      fireEvent.click(addAddressesButton);
+    });
+
+    await waitFor(() => expect(screen.getAllByRole("alert")).toHaveLength(1));
 
     // Address has no errors
-    fireEvent.change(addressInput, { target: { value: newAddress } });
-    fireEvent.click(addAddressesButton);
+    act(() => {
+      fireEvent.change(addressInput, { target: { value: newAddress } });
+    });
+    act(() => {
+      fireEvent.click(addAddressesButton);
+    });
     await waitFor(() =>
       expect(screen.queryByRole("alert")).not.toBeInTheDocument()
     );
   });
 
   it("validates names", async () => {
-    const records = [{ key: existingAddress, val: existingName }];
-    render(
-      <AddAddressesButton
-        records={records}
-        session={mockSession}
-        addAddresses={() => {}}
-      />
-    );
+    const addresses = [{ key: existingAddress, val: existingName }];
+    renderAddAddressesButton({ addresses });
     const addButton = screen.getByRole("button");
-    fireEvent.click(addButton);
+    act(() => {
+      fireEvent.click(addButton);
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("0-address-input")).toBeInTheDocument()
+    );
 
     const addressInput = screen.getByTestId("0-address-input");
-    const addAddressesButton = screen.getByRole("button", { name: "Add" });
-    const nameInput = screen.getByTestId("0-name-input");
-    fireEvent.change(addressInput, { target: { value: newAddress } });
+    act(() => {
+      fireEvent.change(addressInput, { target: { value: newAddress } });
+    });
 
     // Name matches an name that already exists in the system
-    fireEvent.change(nameInput, { target: { value: existingName } });
-    fireEvent.click(addAddressesButton);
-    await waitFor(() => expect(screen.getAllByRole("alert")).toHaveLength(1));
+    const nameInput = screen.getByTestId("0-name-input");
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: existingName } });
+    });
+
+    const addAddressesButton = screen.getByRole("button", { name: "Add" });
+    act(() => {
+      fireEvent.click(addAddressesButton);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(valIsDuplicatedErrorMessage)).toBeInTheDocument()
+    );
 
     // Validate name exists
-    fireEvent.change(nameInput, { target: { value: newName } });
-    fireEvent.click(addAddressesButton);
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: newName } });
+    });
+    act(() => {
+      fireEvent.click(addAddressesButton);
+    });
     await waitFor(() =>
       expect(screen.queryByRole("alert")).not.toBeInTheDocument()
     );

--- a/src/components/__tests__/AddAddressesButton.test.tsx
+++ b/src/components/__tests__/AddAddressesButton.test.tsx
@@ -152,13 +152,13 @@ describe("AddAddressesButton", () => {
 
   describe("validation", () => {
     const addresses = [{ key: existingAddress, val: existingName }];
+    
     beforeEach(() => {
-      localStorage.setAddresses(addresses);
+    localStorage.setLogin({ deviceID: "id", password: "pass" });
+    localStorage.setAddresses(addresses);
     });
 
     it("validates addresses", async () => {
-      const addresses = [{ key: existingAddress, val: existingName }];
-      localStorage.setAddresses(addresses);
       renderAddAddressesButton();
       const addButton = screen.getByRole("button");
       act(() => {
@@ -206,8 +206,7 @@ describe("AddAddressesButton", () => {
     });
 
     it("validates names", async () => {
-      const addresses = [{ key: existingAddress, val: existingName }];
-      renderAddAddressesButton({ addresses });
+      renderAddAddressesButton();
       const addButton = screen.getByRole("button");
       act(() => {
         fireEvent.click(addButton);

--- a/src/components/__tests__/AddressTable.test.tsx
+++ b/src/components/__tests__/AddressTable.test.tsx
@@ -1,36 +1,41 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 import React from "react";
+import { renderMockProvider } from "../../testUtils/MockProvider";
 import { AddressTable } from "../AddressTable";
 
 const addresses = [
   { key: "a", val: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
   { key: "b", val: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
 ];
-const removeSelected = jest.fn();
+const removeAddresses = jest.fn();
 const loading = false;
-const mockAddressTable = (overwrites?) => (
-  <AddressTable
-    {...{
-      addresses,
-      loading,
-      removeSelected,
-      ...overwrites,
-    }}
-  />
-);
+
+const renderAddressTable = (overrides?) =>
+  renderMockProvider({
+    children: (
+      <AddressTable
+        {...{
+          addresses,
+          loading,
+          removeAddresses,
+          ...overrides,
+        }}
+      />
+    ),
+  });
 
 describe("AddressTable", () => {
   it("renders", () => {
-    render(mockAddressTable());
+    renderAddressTable();
   });
 
   it("shows loading", () => {
-    render(mockAddressTable({ loading: true }));
+    renderAddressTable({ loading: true });
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("selects and unselects addresses", () => {
-    render(mockAddressTable());
+    renderAddressTable();
     const checkboxes = screen.getAllByRole("checkbox");
     const removeButton = screen.getByRole("button", {
       name: "Remove Selected",
@@ -45,7 +50,7 @@ describe("AddressTable", () => {
   });
 
   it("handles removing addresses", () => {
-    render(mockAddressTable());
+    renderAddressTable();
     const checkboxes = screen.getAllByRole("checkbox");
     const removeButton = screen.getByRole("button", {
       name: "Remove Selected",
@@ -55,11 +60,11 @@ describe("AddressTable", () => {
     fireEvent.click(selectAll);
     expect(removeButton).not.toBeDisabled();
     fireEvent.click(removeButton);
-    expect(removeSelected).toHaveBeenCalled();
+    expect(removeAddresses).toHaveBeenCalled();
   });
 
   it("filters addresses", () => {
-    render(mockAddressTable());
+    renderAddressTable();
     expect(screen.getByText("a")).toBeInTheDocument();
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "b" } });
@@ -69,7 +74,7 @@ describe("AddressTable", () => {
   });
 
   it("sorts addresses", () => {
-    render(mockAddressTable());
+    renderAddressTable();
     expect(screen.getByText("a")).toBeInTheDocument();
     const sortByName = screen.getByText("Name");
     const sortByAddress = screen.getByText("Address");

--- a/src/components/__tests__/AddressTagsPage.test.tsx
+++ b/src/components/__tests__/AddressTagsPage.test.tsx
@@ -3,22 +3,27 @@ import React from "react";
 import { AddressTagsPage } from "..";
 import { getMockSession, mockKvResponse } from "../../testUtils/getMockSession";
 import { renderMockProvider } from "../../testUtils/MockProvider";
+import localStorage from "../../util/localStorage";
 
 const renderAddressTagsPage = (overrides?) =>
   renderMockProvider({ children: <AddressTagsPage />, ...overrides });
 
 describe("AddressTagsPage", () => {
+  beforeEach(() => {
+    localStorage.removeAddresses();
+  });
+
   it("renders", async () => {
-     waitFor(() => renderAddressTagsPage());
+    waitFor(() => renderAddressTagsPage());
   });
 
   it("fetches addresses on load", async () => {
     const session = getMockSession();
-    waitFor(() => renderAddressTagsPage({ addresses: [], session }));
-     waitFor(() => expect(session.client.getKvRecords).toHaveBeenCalledTimes(1));
+    renderAddressTagsPage({ addresses: [], session })
+    waitFor(() => expect(session.client.getKvRecords).toHaveBeenCalledTimes(1));
   });
 
-  it("fetches many addresses on load",async () => {
+  it("fetches many addresses on load", async () => {
     const session = getMockSession();
     session.client.getKvRecords = jest.fn(() =>
       Promise.resolve({
@@ -26,7 +31,7 @@ describe("AddressTagsPage", () => {
         total: 50,
       })
     );
-    waitFor(()=> renderAddressTagsPage({ session }))
+  renderAddressTagsPage({ session })
     await waitFor(() =>
       expect(session.client.getKvRecords).toHaveBeenCalledTimes(10)
     );
@@ -43,15 +48,13 @@ describe("AddressTagsPage", () => {
           --retries;
         })
     );
-     waitFor(()=>renderAddressTagsPage({ session }))
-     waitFor(() =>
-      expect(session.client.getKvRecords).toHaveBeenCalledTimes(4)
-    );
+    renderAddressTagsPage({ session })
+    waitFor(() => expect(session.client.getKvRecords).toHaveBeenCalledTimes(4));
   });
 
   it("removes addresses", () => {
     const session = getMockSession();
-    waitFor(()=> renderAddressTagsPage({ session }))
+    renderAddressTagsPage({ session });
     const checkboxes = screen.getAllByRole("checkbox");
     const removeButton = screen.getByRole("button", {
       name: "Remove Selected",
@@ -59,11 +62,10 @@ describe("AddressTagsPage", () => {
     expect(removeButton).toBeDisabled();
     const selectAll = checkboxes[0];
 
-    act(()=>{fireEvent.click(selectAll)})
+    fireEvent.click(selectAll);
+    fireEvent.click(removeButton);
 
-    act(()=>{fireEvent.click(removeButton)})
-
-     waitFor(() =>
+    waitFor(() =>
       expect(session.client.removeKvRecords).toHaveBeenCalledTimes(1)
     );
   });

--- a/src/components/__tests__/AddressTagsPage.test.tsx
+++ b/src/components/__tests__/AddressTagsPage.test.tsx
@@ -1,84 +1,70 @@
-import { act,waitFor, screen, render,fireEvent } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { AddressTagsPage } from "..";
-import SDKSession from "../../sdk/sdkSession";
-import { Record } from "../../types/records"
+import { getMockSession, mockKvResponse } from "../../testUtils/getMockSession";
+import { renderMockProvider } from "../../testUtils/MockProvider";
 
-const isMobile = jest.fn();
-const addresses: Record[] = [
-  { id: "a", key: "a", val: "a" },
-  { id: "b", key: "b", val: "b" },
-];
-const response = {
-  records: addresses,
-  fetched: 5,
-  total: 5,
-};
-const session = new SDKSession("", jest.fn(), "", {});
-session.client = {
-  ...session.client,
-  getKvRecords: jest.fn(() => Promise.resolve(response)),
-  removeKvRecords: jest.fn(() => Promise.resolve(true))
-}
-
-const renderAddressTagsPage = async () =>
-  await act(async () => {
-    await render(
-      <AddressTagsPage
-        {...{
-          isMobile,
-          session,
-        }}
-      />
-    );
-  });
+const renderAddressTagsPage = (overrides?) =>
+  renderMockProvider({ children: <AddressTagsPage />, ...overrides });
 
 describe("AddressTagsPage", () => {
   it("renders", async () => {
-    await renderAddressTagsPage();
+     waitFor(() => renderAddressTagsPage());
   });
 
   it("fetches addresses on load", async () => {
-    session.client.getKvRecords = jest.fn(() => Promise.resolve(response));
-    await renderAddressTagsPage();
-    expect(session.client.getKvRecords).toHaveBeenCalledTimes(1);
+    const session = getMockSession();
+    waitFor(() => renderAddressTagsPage({ addresses: [], session }));
+     waitFor(() => expect(session.client.getKvRecords).toHaveBeenCalledTimes(1));
   });
 
-  it("fetches many addresses on load", async () => {
+  it("fetches many addresses on load",async () => {
+    const session = getMockSession();
     session.client.getKvRecords = jest.fn(() =>
       Promise.resolve({
-        ...response,
+        ...mockKvResponse,
         total: 50,
       })
     );
-    await renderAddressTagsPage();
-    expect(session.client.getKvRecords).toHaveBeenCalledTimes(10);
+    waitFor(()=> renderAddressTagsPage({ session }))
+    await waitFor(() =>
+      expect(session.client.getKvRecords).toHaveBeenCalledTimes(10)
+    );
   });
 
-  it("retries to fetch", async () => {
+  it("retries to fetch", () => {
+    const session = getMockSession();
     let retries = 2;
     session.client.getKvRecords = jest.fn(
       () =>
         new Promise((resolve, reject) => {
-          if (!retries) return resolve(response);
+          if (!retries) return resolve(mockKvResponse);
           reject("Error");
           --retries;
         })
-    )
-    await renderAddressTagsPage();
-    expect(session.client.getKvRecords).toHaveBeenCalledTimes(4);
+    );
+     waitFor(()=>renderAddressTagsPage({ session }))
+     waitFor(() =>
+      expect(session.client.getKvRecords).toHaveBeenCalledTimes(4)
+    );
   });
 
-  it("removes addresses", async () => {
-    await renderAddressTagsPage();
+  it("removes addresses", () => {
+    const session = getMockSession();
+    waitFor(()=> renderAddressTagsPage({ session }))
     const checkboxes = screen.getAllByRole("checkbox");
     const removeButton = screen.getByRole("button", {
       name: "Remove Selected",
     });
     expect(removeButton).toBeDisabled();
     const selectAll = checkboxes[0];
-    fireEvent.click(selectAll);
-    fireEvent.click(removeButton);
-    await waitFor(() => expect(session.client.removeKvRecords).toHaveBeenCalledTimes(1));
+
+    act(()=>{fireEvent.click(selectAll)})
+
+    act(()=>{fireEvent.click(removeButton)})
+
+     waitFor(() =>
+      expect(session.client.removeKvRecords).toHaveBeenCalledTimes(1)
+    );
   });
 });

--- a/src/components/__tests__/ContractTable.test.tsx
+++ b/src/components/__tests__/ContractTable.test.tsx
@@ -14,7 +14,7 @@ describe("ContractTable", () => {
 
   it("shows loading", () => {
     renderContractTable();
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    waitFor(()=>expect(screen.getByText("Loading...")).toBeInTheDocument())
   });
 
   it("selects and unselects contracts", async () => {

--- a/src/components/__tests__/ContractTable.test.tsx
+++ b/src/components/__tests__/ContractTable.test.tsx
@@ -1,143 +1,24 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
+import { getMockSession } from "../../testUtils/getMockSession";
+import { renderMockProvider } from "../../testUtils/MockProvider";
 import { ContractTable } from "../ContractTable";
 
-const mockContracts = {
-  records: [
-    {
-      id: "a",
-      header: {
-        sig: "0xe8e33700",
-        name: "a",
-        numParam: 8,
-      },
-      category: "",
-      params: [
-        {
-          name: "tokenA",
-          type: 1,
-          typeName: "address",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "tokenB",
-          type: 1,
-          typeName: "address",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "amountADesired",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "amountBDesired",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "amountAMin",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "amountBMin",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "to",
-          type: 1,
-          typeName: "address",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "deadline",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-      ],
-    },
-    {
-      id: "b",
-      header: {
-        sig: "0x054d50d4",
-        name: "b",
-        numParam: 3,
-      },
-      category: "",
-      params: [
-        {
-          name: "amountIn",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "reserveIn",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-        {
-          name: "reserveOut",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-      ],
-    },
-  ],
-};
-const session = {
-  client: {
-    getAbiRecords: jest.fn(async () => mockContracts),
-    removeAbiRecords: jest.fn(),
-  },
-};
-const mockContractTable = (overwrites?) => (
-  <ContractTable
-    {...{
-      session,
-      ...overwrites,
-    }}
-  />
-);
+const renderContractTable = (overrides?) =>
+  renderMockProvider({ children: <ContractTable />, ...overrides });
 
 describe("ContractTable", () => {
   it("renders", () => {
-    render(mockContractTable());
+    renderContractTable();
   });
 
   it("shows loading", () => {
-    render(mockContractTable());
+    renderContractTable();
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("selects and unselects contracts", async () => {
-    render(mockContractTable());
+    renderContractTable();
     await waitFor(() =>
       expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
     );
@@ -155,7 +36,8 @@ describe("ContractTable", () => {
   });
 
   it("handles removing contracts", async () => {
-    render(mockContractTable());
+    const session = getMockSession();
+    renderContractTable({ session });
     await waitFor(() =>
       expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
     );
@@ -172,7 +54,7 @@ describe("ContractTable", () => {
   });
 
   it("filters contracts", async () => {
-    render(mockContractTable());
+    renderContractTable();
     await waitFor(() =>
       expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
     );
@@ -185,7 +67,7 @@ describe("ContractTable", () => {
   });
 
   it("sorts contracts", async () => {
-    render(mockContractTable());
+    renderContractTable();
     await waitFor(() =>
       expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
     );

--- a/src/components/__tests__/Settings.test.tsx
+++ b/src/components/__tests__/Settings.test.tsx
@@ -1,28 +1,24 @@
+import { fireEvent, screen } from "@testing-library/react";
 import React from "react";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
-import Settings from "../settings";
+import { renderMockProvider } from "../../testUtils/MockProvider";
 import localStorage from "../../util/localStorage";
+import Settings from "../settings";
 
 const testName = "TestKeyRing";
-const newTestName = "NewTestName";
 const testKeyring = () => ({
   TestKeyRing: { name: testName },
   TestKeyRing2: { name: "TestKeyRing2" },
 });
 
+const renderSettings = () => renderMockProvider({ children: <Settings /> });
+
 describe("Settings", () => {
   it("renders", () => {
-    render(<Settings isMobile={false} />);
+    renderSettings();
   });
 
   it("opens keyrings collapsible", () => {
-    render(<Settings isMobile={false} />);
+    renderSettings();
 
     const openButton = screen.getByRole("button", { expanded: false });
     fireEvent.click(openButton);
@@ -34,7 +30,7 @@ describe("Settings", () => {
 
   it("shows keyrings", () => {
     localStorage.setKeyring(testKeyring());
-    render(<Settings isMobile={false} />);
+    renderSettings();
 
     const openButton = screen.getByRole("button", { expanded: false });
     fireEvent.click(openButton);

--- a/src/components/btc-wallet/receive.tsx
+++ b/src/components/btc-wallet/receive.tsx
@@ -4,11 +4,13 @@ import { Button, Card, Row, Input, Empty } from 'antd'
 import { CopyOutlined } from '@ant-design/icons';
 import { PageContent } from '../index'
 import { validateBtcAddr } from '../../util/helpers'
+import { AppContext } from '../../store/AppContext';
 const QRCode = require('qrcode.react');
 const { Search, TextArea } = Input;
 const SEARCH_ID = "address-data";
 
 class Receive extends React.Component<any, any> {
+  static contextType = AppContext;
   constructor(props) {
     super(props);
 
@@ -50,7 +52,7 @@ class Receive extends React.Component<any, any> {
 
 
   renderAddrBox() {
-    if (this.props.isMobile()) {
+    if (this.context.isMobile) {
       return (
         <div>
           <TextArea id={SEARCH_ID}
@@ -118,7 +120,7 @@ class Receive extends React.Component<any, any> {
       </center>      
     )
     return (
-      <PageContent content={content} isMobile={this.props.isMobile}/>
+      <PageContent content={content} />
     )
   }
 }

--- a/src/components/btc-wallet/send.tsx
+++ b/src/components/btc-wallet/send.tsx
@@ -6,10 +6,13 @@ import { PageContent } from '../index'
 import { allChecks } from '../../util/sendChecks';
 import { constants, buildBtcTxReq, getBtcNumTxBytes } from '../../util/helpers'
 import '../styles.css'
+import { AppContext } from '../../store/AppContext';
 const RECIPIENT_ID = "recipient";
 const VALUE_ID = "value";
 
 class Send extends React.Component<any, any> {
+  static contextType = AppContext;
+  
   constructor(props) {
     super(props);
 
@@ -257,7 +260,7 @@ class Send extends React.Component<any, any> {
         />
       )
     } else if (this.state.txHash) {
-      const desc = this.props.isMobile() ? (
+      const desc = this.context.isMobile ? (
         <p>Transaction signed and broadcast successfully.&nbsp;
         <a className='lattice-a' target='_blank' rel='noopener noreferrer' href={this.getUrl()}>View</a></p>
       ) : (
@@ -390,8 +393,7 @@ class Send extends React.Component<any, any> {
       </center>      
     )
     return (
-      <PageContent content={content} isMobile={this.props.isMobile}/>
-    )
+      <PageContent content={content} />    )
   }
 }
 

--- a/src/components/btc-wallet/wallet.tsx
+++ b/src/components/btc-wallet/wallet.tsx
@@ -8,8 +8,11 @@ import {
 } from '@ant-design/icons';
 import { PageContent } from '../index'
 import { constants } from '../../util/helpers'
+import { AppContext } from '../../store/AppContext';
 
 class Wallet extends React.Component<any, any> {
+  static contextType = AppContext;
+
   componentDidMount() {
     if (this.props.session) {
       this.props.session.getBtcWalletData()
@@ -22,7 +25,7 @@ class Wallet extends React.Component<any, any> {
 
   // Make sure text doesn't overflow on smaller screens. We need to trim larger strings
   ensureTrimmedText(text) {
-    if (!this.props.isMobile()) return text;
+    if (!this.context.isMobile) return text;
     const maxChars = this.getInnerWidth() / 22;
     if (text.length > maxChars) return `${text.slice(0, maxChars)}...`
     return text;
@@ -33,7 +36,7 @@ class Wallet extends React.Component<any, any> {
     // Label to view transaction on explorer
     const label = (
       //@ts-expect-error
-      <div align={this.props.isMobile() ? "left" : "right"}>
+      <div align={this.context.isMobile ? "left" : "right"}>
         {item.confirmed ? (
           <p>
             {item.incoming ? 'Received ' : 'Sent '}
@@ -89,7 +92,7 @@ class Wallet extends React.Component<any, any> {
                       )}
       />
     )
-    if (this.props.isMobile()) {
+    if (this.context.isMobile) {
       return (
         <List.Item key={item.hash}>
           <Row justify='center'>{itemMeta}</Row>
@@ -267,7 +270,7 @@ class Wallet extends React.Component<any, any> {
       </center>      
     )
     return (
-      <PageContent content={content} isMobile={this.props.isMobile}/>
+      <PageContent content={content} />
     )
   }
 }

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -6,6 +6,7 @@ import { Settings } from './index'
 import { constants } from '../util/helpers'
 import { NameEditor } from './NameEditor';
 import { LoginData } from '../types/authentication';
+import { AppContext } from '../store/AppContext';
 
 type ConnectProps = {
   submitCb: (data: LoginData, showLoading: boolean) => void,
@@ -13,7 +14,6 @@ type ConnectProps = {
   name: string,
   keyringName: string,
   setKeyringName: (name: string) => void,
-  isMobile: () => boolean,
   errMsg: string
 }
 
@@ -25,6 +25,8 @@ type ConnectState = {
 }
 
 class Connect extends React.Component<ConnectProps, ConnectState> {
+  static contextType = AppContext;
+  
   constructor(props) {
     super(props)
     this.state = {
@@ -173,7 +175,7 @@ class Connect extends React.Component<ConnectProps, ConnectState> {
           onOk={this.hideModal.bind(this)}
           onCancel={this.hideModal.bind(this)}
         >
-          <Settings isMobile={this.props.isMobile} inModal={true} />
+          <Settings inModal={true} />
         </Modal>
       )
     }
@@ -209,8 +211,8 @@ class Connect extends React.Component<ConnectProps, ConnectState> {
   }
 
   render() {
-    const spanWidth = this.props.isMobile() ? 24 : 10;
-    const spanOffset = this.props.isMobile() ? 0 : 7;
+    const spanWidth = this.context.isMobile ? 24 : 10;
+    const spanOffset = this.context.isMobile ? 0 : 7;
     const tooLong = this.props.keyringName !== null && this.props.keyringName.length < 5;
     return (
       <Row>

--- a/src/components/formatting/pageContent.tsx
+++ b/src/components/formatting/pageContent.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import 'antd/dist/antd.dark.css'
 import { Col, Row } from 'antd'
+import { AppContext } from "../../store/AppContext";
 const SPAN_WIDTH = 14; // Max 24 for 100% width
 
 class PageContent extends React.Component<any, any> {
+  static contextType = AppContext
+
   render () {
     if (!this.props.children && !this.props.content)
       return; // Content must be passed in
     // Mobile content should be displayed without any padding
-    if (this.props.isMobile && this.props.isMobile())
+    if (this.context.isMobile)
       return this.props.children ?this.props.children : this.props.content
     // Desktop content has some padding
     return(

--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -64,7 +64,7 @@ class Landing extends React.Component<any, any> {
 
   render() {
     return (
-      <PageContent content={this.renderCard()} isMobile={this.props.isMobile}/>
+      <PageContent content={this.renderCard()}/>
     )
   }
 }

--- a/src/components/loading.tsx
+++ b/src/components/loading.tsx
@@ -22,7 +22,7 @@ class Loading extends React.Component<any, any> {
       </center>
     )
     return (
-      <PageContent content={content} isMobile={this.props.isMobile}/>
+      <PageContent content={content} />
     )
   }
 }

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -279,6 +279,8 @@ class Main extends React.Component<any, MainState> {
     this.context.session.disconnect();
     this.setState({ session: null });
     localStorage.removeLogin()
+    localStorage.removeContracts();
+    localStorage.removeAddresses();
     if (err && err === constants.LOST_PAIRING_MSG)
       //@ts-expect-error
       this.setError({ err })

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -279,8 +279,6 @@ class Main extends React.Component<any, MainState> {
     this.context.session.disconnect();
     this.setState({ session: null });
     localStorage.removeLogin()
-    localStorage.removeContracts();
-    localStorage.removeAddresses();
     if (err && err === constants.LOST_PAIRING_MSG)
       //@ts-expect-error
       this.setError({ err })

--- a/src/components/pair.tsx
+++ b/src/components/pair.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { Card, Input } from 'antd'
 import { PageContent } from './index'
 import 'antd/dist/antd.dark.css'
+import { AppContext } from '../store/AppContext';
 const SUBMIT_LEN = 8; // 8 characters in a code
 
 class Pair extends React.Component<any, any> {
+  static contextType = AppContext;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -52,7 +55,7 @@ class Pair extends React.Component<any, any> {
     if (this.props.hide) {
       return null;
     }
-    const size = this.props.isMobile() ? 'small' : 'large';
+    const size = this.context.isMobile ? 'small' : 'large';
     const width = this.getBoxWidth();
     const fontSize = this.getBoxFontHeight();
     const content = (
@@ -74,7 +77,7 @@ class Pair extends React.Component<any, any> {
       </center>
     )
     return (
-      <PageContent content={content} isMobile={this.props.isMobile}/>
+      <PageContent content={content} />
     )
   }
 }

--- a/src/components/permissions.tsx
+++ b/src/components/permissions.tsx
@@ -231,7 +231,7 @@ class Permissions extends React.Component<any, any> {
       </center>      
     )
     return (
-      <PageContent content={content} isMobile={this.props.isMobile}/>
+      <PageContent content={content} />
     )
   }
 }

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -223,7 +223,7 @@ class Settings extends React.Component<any, any> {
     if (this.props.inModal)
       return (<center>{this.renderCard()}</center>);
     return (
-      <PageContent content={content} isMobile={this.props.isMobile}/>
+      <PageContent content={content} />
     )
   }
 }

--- a/src/components/validateSig.tsx
+++ b/src/components/validateSig.tsx
@@ -3,6 +3,7 @@ import 'antd/dist/antd.dark.css'
 import { Card, Col, Result, Row } from 'antd'
 import { decode } from 'bs58'
 import { constants } from '../util/helpers';
+import { AppContext } from '../store/AppContext';
 const ReactCrypto = require('gridplus-react-crypto').default;
 const EC = require('elliptic').ec;
 
@@ -11,6 +12,8 @@ const SIG_TEMPLATE_LEN =  74; // Struct containing DER sig
 const CERT_TEMPLATE_LEN = 147;  // Struct containing pubkey, permissions, and signature on it
 
 class ValidateSig extends React.Component<any, any> {
+  static contextType = AppContext;
+  
   // Validate a signature for a message from a known signer on a known curve
   // * msg - Expected ASCII string
   // * signer - Expected buffer containing 65-byte public key
@@ -89,8 +92,8 @@ class ValidateSig extends React.Component<any, any> {
 
 
   render() {
-    const spanLength = this.props.isMobile() ? 18 : 10;
-    const spanOffset = this.props.isMobile() ? 3 : 7; 
+    const spanLength = this.context.isMobile ? 18 : 10;
+    const spanOffset = this.context.isMobile ? 3 : 7; 
     return (
       <Row>
         <Col span={spanLength} offset={spanOffset}>

--- a/src/hooks/__tests__/useAddresses.test.tsx
+++ b/src/hooks/__tests__/useAddresses.test.tsx
@@ -1,0 +1,62 @@
+import { act, waitFor } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { getMockSession, mockAddresses } from "../../testUtils/getMockSession";
+import { MockProvider } from "../../testUtils/MockProvider";
+import { useAddresses } from "../useAddresses";
+
+const renderUseAddresses = (overrides?) => {
+  const session = getMockSession();
+  const {
+    result: { current },
+  } = renderHook(() => useAddresses(), {
+    wrapper: ({ children }) => (
+      <MockProvider overrides={{ session, ...overrides }}>
+        {children}
+      </MockProvider>
+    ),
+  });
+  return { ...current, session };
+};
+
+describe("useAddresses", () => {
+  test("should fetch addresses", async () => {
+    const { fetchAddresses, addresses, session } = renderUseAddresses();
+    await act(() => fetchAddresses());
+    expect(session.client.getKvRecords).toHaveBeenCalledTimes(1);
+    waitFor(() => expect(addresses).toStrictEqual(mockAddresses));
+  });
+
+  test("should add addresses", () => {
+    const { addAddresses, addresses } = renderUseAddresses();
+    expect(addresses).toStrictEqual([]);
+    addAddresses(mockAddresses);
+    waitFor(() => expect(addresses).toStrictEqual(mockAddresses));
+  });
+
+  test("should add addresses to state", () => {
+    const { addAddressesToState, addresses } = renderUseAddresses();
+    expect(addresses).toStrictEqual([]);
+    addAddressesToState(mockAddresses);
+    waitFor(() => expect(addresses).toStrictEqual(mockAddresses));
+  });
+
+  test("should remove addresses", () => {
+    const { fetchAddresses, removeAddresses, addresses } = renderUseAddresses();
+    expect(addresses).toStrictEqual([]);
+    fetchAddresses();
+    waitFor(() => expect(addresses).toStrictEqual(mockAddresses));
+    removeAddresses(mockAddresses);
+    waitFor(() => expect(addresses).toStrictEqual([]));
+  });
+
+  test("should remove addresses from state", () => {
+    const { fetchAddresses, removeAddressesFromState, addresses } =
+      renderUseAddresses();
+    expect(addresses).toStrictEqual([]);
+    fetchAddresses();
+    waitFor(() => expect(addresses).toStrictEqual(mockAddresses));
+    removeAddressesFromState(mockAddresses);
+    waitFor(() => expect(addresses).toStrictEqual([]));
+  });
+});

--- a/src/hooks/__tests__/useContracts.test.tsx
+++ b/src/hooks/__tests__/useContracts.test.tsx
@@ -1,0 +1,62 @@
+import { act, waitFor } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { getMockSession, mockContracts } from "../../testUtils/getMockSession";
+import { MockProvider } from "../../testUtils/MockProvider";
+import { useContracts } from "../useContracts";
+
+const renderUseContracts = (overrides?) => {
+  const session = getMockSession();
+  const {
+    result: { current },
+  } = renderHook(() => useContracts(), {
+    wrapper: ({ children }) => (
+      <MockProvider overrides={{ session, ...overrides }}>
+        {children}
+      </MockProvider>
+    ),
+  });
+  return { ...current, session };
+};
+
+describe("useContracts", () => {
+  test("should fetch contracts", async () => {
+    const { fetchContracts, contracts, session } = renderUseContracts();
+    await act(() => fetchContracts());
+    expect(session.client.getAbiRecords).toHaveBeenCalledTimes(1);
+    waitFor(() => expect(contracts).toStrictEqual(mockContracts));
+  });
+
+  test("should add contracts", () => {
+    const { addContracts, contracts } = renderUseContracts();
+    expect(contracts).toStrictEqual([]);
+    addContracts(mockContracts);
+    waitFor(() => expect(contracts).toStrictEqual(mockContracts));
+  });
+
+  test("should add contracts to state", () => {
+    const { addContractsToState, contracts } = renderUseContracts();
+    expect(contracts).toStrictEqual([]);
+    addContractsToState(mockContracts);
+    waitFor(() => expect(contracts).toStrictEqual(mockContracts));
+  });
+
+  test("should remove contracts", () => {
+    const { fetchContracts, removeContracts, contracts } = renderUseContracts();
+    expect(contracts).toStrictEqual([]);
+    fetchContracts();
+    waitFor(() => expect(contracts).toStrictEqual(mockContracts));
+    removeContracts(mockContracts.records);
+    waitFor(() => expect(contracts).toStrictEqual([]));
+  });
+
+  test("should remove contracts from state", () => {
+    const { fetchContracts, removeContractsFromState, contracts } =
+      renderUseContracts();
+    expect(contracts).toStrictEqual([]);
+    fetchContracts();
+    waitFor(() => expect(contracts).toStrictEqual(mockContracts));
+    removeContractsFromState(mockContracts);
+    waitFor(() => expect(contracts).toStrictEqual([]));
+  });
+});

--- a/src/hooks/__tests__/useFeature.test.tsx
+++ b/src/hooks/__tests__/useFeature.test.tsx
@@ -1,42 +1,34 @@
-import { act, renderHook } from "@testing-library/react-hooks";
-import result from "antd/lib/result";
-import SDKSession from "../../sdk/sdkSession";
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { MockProvider } from "../../testUtils/MockProvider";
 import { useFeature } from "../useFeature";
+
+const renderUseFeature = ([ fix, minor, major ], overrides?): any => {
+  const session = {
+    client: {
+      getFwVersion: () => ({ fix, minor, major }),
+    },
+  };
+  const {
+    result: { current },
+  } = renderHook(() => useFeature(), {
+    wrapper: ({ children }) => (
+      <MockProvider overrides={{ session, ...overrides }}>
+        {children}
+      </MockProvider>
+    ),
+  });
+  return { ...current, session };
+};
 
 describe("useFeature", () => {
   test("should return false if version is too low", () => {
-    const session = {
-      client: {
-        getFwVersion: () => ({
-          fix: 0,
-          minor: 10,
-          major: 5,
-        }),
-      },
-    };
-    const {
-      result: {
-        current: { CAN_VIEW_CONTRACTS },
-      },
-    } = renderHook(() => useFeature(session));
+    const { CAN_VIEW_CONTRACTS } = renderUseFeature([0,10,5])
     expect(CAN_VIEW_CONTRACTS).toBeFalsy();
   });
 
   test("should return true if version is greater than needed", () => {
-    const session = {
-      client: {
-        getFwVersion: () => ({
-          fix: 0,
-          minor: 15,
-          major: 0,
-        }),
-      },
-    };
-    const {
-      result: {
-        current: { CAN_VIEW_CONTRACTS },
-      },
-    } = renderHook(() => useFeature(session));
+    const { CAN_VIEW_CONTRACTS } = renderUseFeature([0, 15, 0]);
     expect(CAN_VIEW_CONTRACTS).toBeTruthy();
   });
 });

--- a/src/hooks/__tests__/useRequestFailed.test.tsx
+++ b/src/hooks/__tests__/useRequestFailed.test.tsx
@@ -1,0 +1,38 @@
+import { waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useRequestFailed } from "../useRequestFailed";
+
+const renderUseRequestFailed = () => {
+  const {
+    result: { current },
+  } = renderHook(() => useRequestFailed());
+  return current;
+};
+describe("useRequestFailed", () => {
+  test("should reset retry function", () => {
+    const { retryFunction, setRetryFunctionWithReset } =
+      renderUseRequestFailed();
+    const mockFn = jest.fn();
+
+    act(() => setRetryFunctionWithReset(mockFn));
+    waitFor(() => expect(retryFunction).toBeTruthy());
+
+    act(() => mockFn());
+    waitFor(() => expect(retryFunction).toBeFalsy());
+  });
+
+  test("should reset error", () => {
+    const { error, setError, setRetryFunctionWithReset } =
+      renderUseRequestFailed();
+    const mockFn = jest.fn();
+    const mockErr = "error";
+
+    act(() => setRetryFunctionWithReset(mockFn));
+
+    act(() => setError(mockErr));
+    waitFor(() => expect(error).toBe(mockErr));
+
+    act(() => mockFn());
+    waitFor(() => expect(error).toBeFalsy());
+  });
+});

--- a/src/hooks/useAddresses.tsx
+++ b/src/hooks/useAddresses.tsx
@@ -1,0 +1,130 @@
+import isEmpty from "lodash/isEmpty";
+import { useCallback, useContext, useState } from "react";
+import { AppContext } from "../store/AppContext";
+import { Record } from "../types/records";
+import { constants } from "../util/helpers";
+import { useRequestFailed } from "./useRequestFailed";
+const { ADDRESSES_PER_PAGE } = constants;
+const ADDRESS_RECORD_TYPE = 0;
+
+/**
+ * The `useAddresses` hook is used to manage the external calls for fetching, adding, and removing
+ * key-value address data on the user's Lattice.
+ */
+export const useAddresses = () => {
+  const { session, addresses, addAddressesToState, removeAddressesFromState } =
+    useContext(AppContext);
+
+  const {
+    error,
+    setError,
+    retryFunction,
+    setRetryFunctionWithReset,
+  } = useRequestFailed();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+
+  /**
+   * Fetches the installed addresses from the user's Lattice.
+   */
+  const fetchAddresses = useCallback(
+    async (fetched = 0, retries = 1) => {
+      setIsLoading(true);
+
+      return session.client
+        .getKvRecords({
+          start: fetched,
+          n: ADDRESSES_PER_PAGE,
+        })
+        .then((res: any) => {
+          addAddressesToState(res.records);
+          const totalFetched = res.fetched + fetched;
+          const remainingToFetch = res.total - totalFetched;
+          if (remainingToFetch > 0) {
+            fetchAddresses(fetched + res.fetched);
+          } else {
+            setError(null);
+            setIsLoading(false);
+          }
+        })
+        .catch((err) => {
+          if (retries > 0) {
+            setError(null);
+            fetchAddresses(fetched, retries - 1);
+          } else {
+            setError(err);
+            setIsLoading(false);
+            setRetryFunctionWithReset(fetchAddresses);
+          }
+        });
+    },
+    [
+      addAddressesToState,
+      session.client,
+      setError,
+      setIsLoading,
+      setRetryFunctionWithReset,
+    ]
+  );
+
+  /**
+   * Removes installed addresses from the user's Lattice.
+   */
+  const removeAddresses = (selectedAddresses: Record[]) => {
+    const ids = selectedAddresses.map((r) => parseInt(r.id));
+    if (isEmpty(ids)) return;
+    setIsLoading(true);
+
+    return session.client
+      .removeKvRecords({ ids })
+      .then(() => {
+        removeAddressesFromState(selectedAddresses);
+        setError(null);
+      })
+      .catch((err) => {
+        setError(err);
+        setRetryFunctionWithReset(() => removeAddresses(selectedAddresses));
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  /**
+   * Installs new addresses to the user's Lattice.
+   */
+  const addAddresses = async (records: Record[]) => {
+    setIsLoading(true);
+
+    return session.client
+      .addKvRecords({
+        caseSensitive: false,
+        type: ADDRESS_RECORD_TYPE,
+        records,
+      })
+      .then(() => {
+        addAddressesToState(records);
+      })
+      .catch((err) => {
+        setError(err);
+        setRetryFunctionWithReset(() => addAddresses(records));
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  return {
+    fetchAddresses,
+    addresses,
+    addAddresses,
+    addAddressesToState,
+    removeAddresses,
+    removeAddressesFromState,
+    isLoading,
+    error,
+    setError,
+    retryFunction,
+  };
+};

--- a/src/hooks/useAddresses.tsx
+++ b/src/hooks/useAddresses.tsx
@@ -21,7 +21,7 @@ export const useAddresses = () => {
     addAddressesToState,
     removeAddressesFromState,
     resetAddressesInState,
-  ] = useRecords(localStorage.getAddresses());
+  ] = useRecords(localStorage.getAddresses() ?? []);
 
   const { error, setError, retryFunction, setRetryFunctionWithReset } =
     useRequestFailed();

--- a/src/hooks/useAddresses.tsx
+++ b/src/hooks/useAddresses.tsx
@@ -37,7 +37,7 @@ export const useAddresses = () => {
           start: fetched,
           n: ADDRESSES_PER_PAGE,
         })
-        .then((res: any) => {
+        .then((res) => {
           addAddressesToState(res.records);
           const totalFetched = res.fetched + fetched;
           const remainingToFetch = res.total - totalFetched;

--- a/src/hooks/useContracts.tsx
+++ b/src/hooks/useContracts.tsx
@@ -2,10 +2,7 @@ import isEmpty from "lodash/isEmpty";
 import { useCallback, useContext, useEffect, useState } from "react";
 import SDKSession from "../sdk/sdkSession";
 import { AppContext } from "../store/AppContext";
-import {
-  ContractRecord,
-  LatticeContract
-} from "../types/contracts";
+import { ContractRecord, LatticeContract } from "../types/contracts";
 import { transformLatticeContractToContractRecord } from "../util/contracts";
 import { constants } from "../util/helpers";
 import localStorage from "../util/localStorage";
@@ -148,20 +145,34 @@ export const useContracts = () => {
   );
 
   /**
+   *  Fetches `ContractPacks` by fetching the index and then each pack.
+   */
+  const fetchContractPacks = useCallback(() => {
+    setIsLoading(true);
+    fetchContractPackIndex()
+      .then(async (packs) => {
+        setContractPacks(await Promise.all(packs.map(fetchContractPack)));
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [fetchContractPack, fetchContractPackIndex]);
+
+  /**
+   * Resets `ContractPacks` data to it's default.
+   */
+  const resetContractPacksInState = useCallback(() => {
+    localStorage.removeContractPacks();
+  }, []);
+
+  /**
    *  Fetch and save `ContractPacks` data.
    */
   useEffect(() => {
     if (isEmpty(contractPacks)) {
-      fetchContractPackIndex().then(async (packs) => {
-        setContractPacks(await Promise.all(packs.map(fetchContractPack)));
-      });
+      fetchContractPacks();
     }
-  }, [
-    contractPacks,
-    fetchContractPack,
-    fetchContractPackIndex,
-    setContractPacks,
-  ]);
+  }, [contractPacks, fetchContractPacks]);
 
   /**
    * Whenever `contracts` data changes, it is persisted to `localStorage`
@@ -180,8 +191,8 @@ export const useContracts = () => {
   return {
     contractPacks,
     fetchContracts,
-    fetchContractPack,
-    fetchContractPackIndex,
+    fetchContractPacks,
+    resetContractPacksInState,
     isLoading,
     setIsLoading,
     contracts,

--- a/src/hooks/useContracts.tsx
+++ b/src/hooks/useContracts.tsx
@@ -38,11 +38,10 @@ export const useContracts = () => {
 
       return session.client
         .getAbiRecords({
-          n: CONTRACTS_PER_PAGE,
           startIdx: fetched,
-          category: "",
+          n: CONTRACTS_PER_PAGE,
         })
-        .then((res: any) => {
+        .then((res) => {
           const _contracts = res.records.map((r) => ({
             id: r.header.name,
             ...r,
@@ -163,6 +162,7 @@ export const useContracts = () => {
     fetchContractPack,
     fetchContractPackIndex,
     isLoading,
+    setIsLoading,
     contracts,
     addContracts,
     removeContracts,

--- a/src/hooks/useContracts.tsx
+++ b/src/hooks/useContracts.tsx
@@ -23,7 +23,7 @@ export const useContracts = () => {
     addContractsToState,
     removeContractsFromState,
     resetContractsInState,
-  ] = useRecords<ContractRecord>(localStorage.getContracts());
+  ] = useRecords<ContractRecord>(localStorage.getContracts() ?? []);
 
   const [contractPacks, setContractPacks] = useState(
     localStorage.getContractPacks()

--- a/src/hooks/useContracts.tsx
+++ b/src/hooks/useContracts.tsx
@@ -1,0 +1,175 @@
+import isEmpty from "lodash/isEmpty";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { AppContext } from "../store/AppContext";
+import { Record } from "../types/records";
+import { constants } from "../util/helpers";
+import { useRequestFailed } from "./useRequestFailed";
+const { CONTRACTS_PER_PAGE, ABI_PACK_URL } = constants;
+
+/**
+ * The `useContracts` hook is used to manage the external calls for fetching, adding, and removing
+ * contract data on the user's Lattice; as well as fetching the public contract pack data.
+ */
+export const useContracts = () => {
+  const {
+    session,
+    contracts,
+    addContractsToState,
+    removeContractsFromState,
+    contractPacks,
+    setContractPacks,
+  } = useContext(AppContext);
+
+  const {
+    error,
+    setError,
+    retryFunction,
+    setRetryFunctionWithReset,
+  } = useRequestFailed();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  /**
+   * Fetches the installed ABI contracts from the user's Lattice.
+   */
+  const fetchContracts = useCallback(
+    async (fetched = 0, retries = 1) => {
+      setIsLoading(true);
+
+      return session.client
+        .getAbiRecords({
+          n: CONTRACTS_PER_PAGE,
+          startIdx: fetched,
+          category: "",
+        })
+        .then((res: any) => {
+          const _contracts = res.records.map((r) => ({
+            id: r.header.name,
+            ...r,
+          }));
+          addContractsToState(_contracts);
+          const totalFetched = res.numFetched + fetched;
+          const remainingToFetch = res.numRemaining;
+          if (remainingToFetch > 0) {
+            fetchContracts(totalFetched);
+          } else {
+            setIsLoading(false);
+          }
+        })
+        .catch((err) => {
+          if (retries > 0) {
+            setError(null);
+            fetchContracts(fetched, retries - 1);
+          } else {
+            setError(err);
+            setIsLoading(false);
+            setRetryFunctionWithReset(fetchContracts);
+          }
+        });
+    },
+    [
+      addContractsToState,
+      session.client,
+      setError,
+      setIsLoading,
+      setRetryFunctionWithReset,
+    ]
+  );
+
+  /**
+   * Removes installed ABI contracts from the user's Lattice.
+   */
+  const removeContracts = (contractsToRemove: Record[]) => {
+    setIsLoading(true);
+    const sigs = contractsToRemove.map((c) => c.header.sig);
+
+    return session.client
+      .removeAbiRecords({ sigs })
+      .then(() => {
+        removeContractsFromState(contractsToRemove);
+      })
+      .catch((err) => {
+        setError(err);
+        setRetryFunctionWithReset(() => removeContracts(contractsToRemove));
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  /**
+   * Installs new ABI contracts to the user's Lattice.
+   */
+  const addContracts = (contracts) => {
+    setIsLoading(true);
+    session.client.timeout = 2 * constants.ASYNC_SDK_TIMEOUT;
+
+    return session.client
+      .addAbiDefs(contracts)
+      .then(() => {
+        addContractsToState(contracts);
+      })
+      .catch((err) => {
+        setError(err);
+        setRetryFunctionWithReset(() => removeContracts(contracts));
+      })
+      .finally(() => {
+        setIsLoading(false);
+        session.client.timeout = constants.ASYNC_SDK_TIMEOUT;
+      });
+  };
+
+  /**
+   * Fetches the index of the publicly available contract pack data.
+   */
+  const fetchContractPackIndex = useCallback(
+    () =>
+      fetch(`${ABI_PACK_URL}/`)
+        .then((res) => res.json())
+        .catch(console.error),
+    []
+  );
+
+  /**
+   * Fetches the individual contract pack data for a given pack's `fname`.
+   */
+  const fetchContractPack = useCallback(
+    (pack) =>
+      fetch(`${ABI_PACK_URL}/${pack.fname}`)
+        .then((res) => res.json())
+        .catch(console.error),
+    []
+  );
+
+  /**
+   *  Fetch and save `ContractPacks` data.
+   */
+  useEffect(() => {
+    if (isEmpty(contractPacks)) {
+      fetchContractPackIndex().then(async (packs) => {
+        setContractPacks(await Promise.all(packs.map(fetchContractPack)));
+      });
+    }
+  }, [
+    contractPacks,
+    fetchContractPack,
+    fetchContractPackIndex,
+    setContractPacks,
+  ]);
+
+  return {
+    contractPacks,
+    fetchContracts,
+    fetchContractPack,
+    fetchContractPackIndex,
+    isLoading,
+    contracts,
+    addContracts,
+    removeContracts,
+    addContractsToState,
+    removeContractsFromState,
+    error,
+    setError,
+    retryFunction,
+  };
+};

--- a/src/hooks/useFeature.tsx
+++ b/src/hooks/useFeature.tsx
@@ -1,4 +1,5 @@
-import SDKSession from "../sdk/sdkSession";
+import { useContext } from "react";
+import { AppContext } from "../store/AppContext";
 
 /**
  * `useFeature` is a React hook for feature flags that makes it easy to know when a particular
@@ -6,7 +7,8 @@ import SDKSession from "../sdk/sdkSession";
  * 
  * To add a feature, add a SNAKE_CASE key to the `features` variable with a value of 
  */
- export const useFeature = ( session: SDKSession): { [feature: string]: boolean } => {
+export const useFeature = (): { [feature: string]: boolean } => {
+  const { session } = useContext(AppContext);
   const { fix, minor, major } = session.client.getFwVersion();
 
   const features = {

--- a/src/hooks/useFeature.tsx
+++ b/src/hooks/useFeature.tsx
@@ -5,7 +5,8 @@ import { AppContext } from "../store/AppContext";
  * `useFeature` is a React hook for feature flags that makes it easy to know when a particular
  * feature is active for a version of the Lattice firmware (or other external data).
  * 
- * To add a feature, add a SNAKE_CASE key to the `features` variable with a value of 
+ * To add a feature, add a SNAKE_CASE key to the `features` variable with an array that specifies
+ * the required version of firmware as [fix, minor, major].
  */
 export const useFeature = (): { [feature: string]: boolean } => {
   const { session } = useContext(AppContext);

--- a/src/hooks/useRecords.tsx
+++ b/src/hooks/useRecords.tsx
@@ -5,23 +5,26 @@ import { Record } from "../types/records";
 
 /**
  * `useRecords` is a React hook that builds off of `useState` to add setter functions for
- * interacting with a list:
+ * interacting with a list of objects:
  *  - `addRecords` - Combines passed in array of records and records in state by comparing ids
  *  - `removeRecords` - Removes passed in array of records from records in state by comparing ids
  * @param defaultValue - any array to set the default value
  */
-export const useRecords = (
-  defaultValue: Record[], id="id"
-): [Record[], (toAdd: Record[]) => void, (toRemove: Record[]) => void] => {
-  const [records, setRecords] = useState(defaultValue);
+export const useRecords = <T extends Record>(
+  defaultValue: T[],
+  id = "id"
+): [T[], (toAdd: T[]) => void, (toRemove: T[]) => void, () => void] => {
+  const [records, setRecords] = useState<T[]>(defaultValue);
 
-  const addRecords = (recordsToAdd: Record[]) =>
+  const addRecords = (recordsToAdd: T[]) =>
     setRecords((recordsInState) => unionBy(recordsInState, recordsToAdd, id));
 
-  const removeRecords = (recordsToRemove: Record[]) =>
+  const removeRecords = (recordsToRemove: T[]) =>
     setRecords((recordsInState) =>
       differenceBy(recordsInState, recordsToRemove, id)
     );
 
-  return [records, addRecords, removeRecords];
+  const resetRecords = () => setRecords([]);
+
+  return [records, addRecords, removeRecords, resetRecords];
 };

--- a/src/hooks/useRequestFailed.tsx
+++ b/src/hooks/useRequestFailed.tsx
@@ -1,0 +1,32 @@
+import { useCallback, useState } from "react";
+
+/**
+ * The `useRequestFailed` hook is used to more easily manage the state of a request as it is loading,
+ * responding with errors, or retrying.
+ */
+export const useRequestFailed = () => {
+  const [error, setError] = useState(undefined);
+  const [retryFunction, setRetryFunction] = useState(undefined);
+
+  /**
+   * Wraps the `retryFunction` in another function that will not only call the `retryFunction` but
+   * also reset the state of the `error` and `retryFunction` variables.
+   */
+  const setRetryFunctionWithReset = useCallback(
+    (func) =>
+      setRetryFunction(() => () => {
+        func();
+        setError(null);
+        setRetryFunction(null);
+      }),
+    [setRetryFunction]
+  );
+
+  return {
+    error,
+    setError,
+    retryFunction,
+    setRetryFunction,
+    setRetryFunctionWithReset,
+  };
+};

--- a/src/store/AppContext.tsx
+++ b/src/store/AppContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, ReactNode, useEffect, useState } from "react";
+import { useRecords } from "../hooks/useRecords";
+import SDKSession from "../sdk/sdkSession";
+import localStorage from "../util/localStorage";
+
+/**
+ * A React Hook that allows us to pass data down the component tree without having to pass
+ * props.
+ */
+export const AppContext = createContext(undefined);
+
+export const AppContextProvider = ({
+  children,
+  overrides,
+}: {
+  children: ReactNode;
+  overrides?: { [key: string]: any };
+}) => {
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 500);
+  const [session, setSession] = useState<SDKSession>(null);
+  const [addresses, addAddressesToState, removeAddressesFromState] = useRecords(
+    []
+  );
+  const [contracts, addContractsToState, removeContractsFromState] = useRecords(
+    []
+  );
+  const [contractPacks, setContractPacks] = useState([]);
+
+  const defaultContext = {
+    isMobile,
+    session,
+    setSession,
+    addresses,
+    addAddressesToState,
+    removeAddressesFromState,
+    contracts,
+    addContractsToState,
+    removeContractsFromState,
+    contractPacks,
+    setContractPacks,
+  };
+
+  /**
+   * Sets `isMobile` when the window resizes.
+   * */
+  useEffect(() => {
+    window.addEventListener("resize", () => {
+      const windowIsMobileWidth = window.innerWidth < 500;
+      if (windowIsMobileWidth && !isMobile) setIsMobile(true);
+      if (!windowIsMobileWidth && isMobile) setIsMobile(false);
+    });
+  }, [isMobile]);
+
+  return (
+    <AppContext.Provider value={{ ...defaultContext, ...overrides }}>
+      {children}
+    </AppContext.Provider>
+  );
+};

--- a/src/store/AppContext.tsx
+++ b/src/store/AppContext.tsx
@@ -1,7 +1,5 @@
 import React, { createContext, ReactNode, useEffect, useState } from "react";
-import { useRecords } from "../hooks/useRecords";
 import SDKSession from "../sdk/sdkSession";
-import localStorage from "../util/localStorage";
 
 /**
  * A React Hook that allows us to pass data down the component tree without having to pass
@@ -18,26 +16,11 @@ export const AppContextProvider = ({
 }) => {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 500);
   const [session, setSession] = useState<SDKSession>(null);
-  const [addresses, addAddressesToState, removeAddressesFromState] = useRecords(
-    []
-  );
-  const [contracts, addContractsToState, removeContractsFromState] = useRecords(
-    []
-  );
-  const [contractPacks, setContractPacks] = useState([]);
 
   const defaultContext = {
     isMobile,
     session,
     setSession,
-    addresses,
-    addAddressesToState,
-    removeAddressesFromState,
-    contracts,
-    addContractsToState,
-    removeContractsFromState,
-    contractPacks,
-    setContractPacks,
   };
 
   /**

--- a/src/testUtils/MockProvider.tsx
+++ b/src/testUtils/MockProvider.tsx
@@ -1,0 +1,45 @@
+import { act, render } from "@testing-library/react";
+import React, { ReactNode } from "react";
+import { AppContextProvider } from "../store/AppContext";
+import { getMockSession } from "./getMockSession";
+
+/**
+ * Component that wraps children components with the `AppContextProvider` and
+ * accepts an override object that can be used to mock any properties in the `AppContext`.
+ *
+ * @param children The children of the component.
+ */
+export const MockProvider = ({
+  children,
+  overrides,
+}: {
+  children: ReactNode;
+  overrides?;
+}) => (
+  <AppContextProvider overrides={{ ...overrides }}>
+    {children}
+  </AppContextProvider>
+);
+
+/**
+ * Renders a React component wrapped by the `AppContext` with the given overrides
+ * and a `Session` object that is pre-populated.
+ *
+ * @param children The React component(s) to render.
+ */
+export const renderMockProvider = ({
+  children,
+  ...overrides
+}: {
+  children: ReactNode;
+  overrides?;
+}) => {
+  const session = getMockSession();
+   act(() => {
+    render(
+      <MockProvider overrides={{ session, ...overrides }}>
+        {children}
+      </MockProvider>
+    );
+  });
+};

--- a/src/testUtils/MockProvider.tsx
+++ b/src/testUtils/MockProvider.tsx
@@ -4,10 +4,10 @@ import { AppContextProvider } from "../store/AppContext";
 import { getMockSession } from "./getMockSession";
 
 /**
- * Component that wraps children components with the `AppContextProvider` and
- * accepts an override object that can be used to mock any properties in the `AppContext`.
+ * Component that wraps children components with the `AppContextProvider` and accepts an override
+ * object that can be used to mock any properties in the `AppContext`.
  *
- * @param children The children of the component.
+ * @param children The React component(s) to render.
  */
 export const MockProvider = ({
   children,
@@ -22,8 +22,8 @@ export const MockProvider = ({
 );
 
 /**
- * Renders a React component wrapped by the `AppContext` with the given overrides
- * and a `Session` object that is pre-populated.
+ * Renders a React component wrapped by the `AppContext` with the given overrides and a `Session`
+ * object that is pre-populated.
  *
  * @param children The React component(s) to render.
  */
@@ -35,7 +35,7 @@ export const renderMockProvider = ({
   overrides?;
 }) => {
   const session = getMockSession();
-   act(() => {
+  act(() => {
     render(
       <MockProvider overrides={{ session, ...overrides }}>
         {children}

--- a/src/testUtils/getMockSession.ts
+++ b/src/testUtils/getMockSession.ts
@@ -1,0 +1,79 @@
+import SDKSession from "../sdk/sdkSession";
+import { Record } from "../types/records";
+
+export const mockAddresses: Record[] = [
+  { id: "a", key: "a", val: "a" },
+  { id: "b", key: "b", val: "b" },
+];
+
+export const mockKvResponse = {
+  records: mockAddresses,
+  fetched: 5,
+  total: 5,
+};
+
+export const mockContracts = {
+  records: [
+    {
+      id: "a",
+      header: {
+        sig: "0xe8e33700",
+        name: "a",
+        numParam: 8,
+      },
+      category: "",
+      params: [
+        {
+          name: "tokenA",
+          type: 1,
+          typeName: "address",
+          isArray: 0,
+          arraySz: 0,
+        },
+      ],
+    },
+    {
+      id: "b",
+      header: {
+        sig: "0x054d50d4",
+        name: "b",
+        numParam: 3,
+      },
+      category: "",
+      params: [
+        {
+          name: "amountIn",
+          type: 34,
+          typeName: "uint256",
+          isArray: 0,
+          arraySz: 0,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * `getMockSession` returns a mock Session object with a mocked Client object that has its public
+ * functions mocked for testing.
+ *
+ * @param `overrides` key-values that will override any values (supersedes `clientOverrides`)
+ * @param `clientOverrides`: key-values that will override any `Client` values
+ */
+export const getMockSession = (
+  { overrides, clientOverrides } = {
+    overrides: {} as any,
+    clientOverrides: {} as any,
+  }
+): SDKSession => ({
+  client: {
+    addKvRecords: jest.fn(async (records) => records),
+    getKvRecords: jest.fn(async () => mockKvResponse),
+    removeKvRecords: jest.fn(async () => true),
+    getAbiRecords: jest.fn(async () => mockContracts),
+    removeAbiRecords: jest.fn(async () => true),
+    addAbiDefs: jest.fn(async (defs) => defs),
+    ...clientOverrides,
+  },
+  ...overrides,
+});

--- a/src/testUtils/getMockSession.ts
+++ b/src/testUtils/getMockSession.ts
@@ -1,5 +1,7 @@
+import { act } from "@testing-library/react";
 import SDKSession from "../sdk/sdkSession";
 import { Record } from "../types/records";
+import { ContractRecord } from "./../types/contracts";
 
 export const mockAddresses: Record[] = [
   { id: "a", key: "a", val: "a" },
@@ -12,53 +14,60 @@ export const mockKvResponse = {
   total: 5,
 };
 
-export const mockContracts = {
-  records: [
-    {
-      id: "a",
-      header: {
-        sig: "0xe8e33700",
-        name: "a",
-        numParam: 8,
-      },
-      category: "",
-      params: [
-        {
-          name: "tokenA",
-          type: 1,
-          typeName: "address",
-          isArray: 0,
-          arraySz: 0,
-        },
-      ],
+
+export const mockContracts: ContractRecord[] = [
+  {
+    id: "a",
+    header: {
+      sig: "0xe8e33700",
+      name: "a",
+      numParam: 8,
     },
-    {
-      id: "b",
-      header: {
-        sig: "0x054d50d4",
-        name: "b",
-        numParam: 3,
+    category: "",
+    sig: "0xe8e33700",
+    name: "a",
+    params: [
+      {
+        name: "tokenA",
+        type: 1,
+        latticeTypeIdx: 0,
+        isArray: false,
+        arraySz: 0,
       },
-      category: "",
-      params: [
-        {
-          name: "amountIn",
-          type: 34,
-          typeName: "uint256",
-          isArray: 0,
-          arraySz: 0,
-        },
-      ],
+    ],
+  },
+  {
+    id: "b",
+    header: {
+      sig: "0x054d50d4",
+      name: "b",
+      numParam: 3,
     },
-  ],
-};
+    sig: "0x054d50d4",
+    name: "b",
+    category: "",
+    params: [
+      {
+        name: "amountIn",
+        type: 34,
+        latticeTypeIdx: 0,
+        isArray: false,
+        arraySz: 0,
+      },
+    ],
+  },
+];
+
+export const mockContractResponse: { records: ContractRecord[] } = {
+  records: mockContracts
+}
 
 /**
- * `getMockSession` returns a mock Session object with a mocked Client object that has its public
+ * `getMockSession` returns a mock Session object with a Client object that has its public
  * functions mocked for testing.
  *
- * @param `overrides` key-values that will override any values (supersedes `clientOverrides`)
- * @param `clientOverrides`: key-values that will override any `Client` values
+ * @param `overrides` key-values that will override any `SDKSession` properties (supersedes `clientOverrides`).
+ * @param `clientOverrides` key-values that will override any `Client` properties.
  */
 export const getMockSession = (
   { overrides, clientOverrides } = {
@@ -67,10 +76,13 @@ export const getMockSession = (
   }
 ): SDKSession => ({
   client: {
+    // Addresses
     addKvRecords: jest.fn(async (records) => records),
     getKvRecords: jest.fn(async () => mockKvResponse),
     removeKvRecords: jest.fn(async () => true),
-    getAbiRecords: jest.fn(async () => mockContracts),
+    
+    //Contracts
+    getAbiRecords: jest.fn(async () => mockContractResponse),
     removeAbiRecords: jest.fn(async () => true),
     addAbiDefs: jest.fn(async (defs) => defs),
     ...clientOverrides,

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -1,0 +1,32 @@
+import { Record } from "./records";
+
+type ContractParam = {
+  isArray: boolean;
+  type: number;
+  arraySz: number;
+  name: string;
+  latticeTypeIdx: number;
+};
+
+export interface ContractDefinition {
+  name: string;
+  sig: string;
+  params: ContractParam[];
+}
+
+export interface LatticeContract {
+  category: string;
+  header: {
+    name: string;
+    sig: string;
+    numParam: number;
+  };
+  params: ContractParam[];
+}
+
+export interface ContractRecord
+  extends Record,
+    LatticeContract,
+    ContractDefinition {
+  id: string;
+}

--- a/src/util/__tests__/contracts.test.ts
+++ b/src/util/__tests__/contracts.test.ts
@@ -1,0 +1,45 @@
+import { ContractDefinition, ContractRecord, LatticeContract } from "./../../types/contracts";
+import {
+  transformContractDefinitionToContractRecord,
+  transformLatticeContractToContractRecord,
+} from "../contracts";
+
+describe("contract utilities", () => {
+  test("transforms ContractDefinition to ContractRecord", () => {
+    const mockDef: ContractDefinition = { name: "a", sig: "a", params: [] };
+  
+    const expected: ContractRecord = {
+      category: "",
+      header: { name: "a", numParam: 0, sig: "a" },
+      id: "a",
+      name: "a",
+      params: [],
+      sig: "a",
+    };
+
+    expect(transformContractDefinitionToContractRecord(mockDef)).toStrictEqual(
+      expected
+    );
+  });
+  
+  test("transforms LatticeContract to ContractRecord", () => {
+    const mockDef: LatticeContract = {
+      category: "",
+      header: { name: "a", sig: "a", numParam: 0 },
+      params: [],
+    };
+
+    const expected: ContractRecord = {
+      category: "",
+      header: { name: "a", numParam: 0, sig: "a" },
+      id: "a",
+      name: "a",
+      params: [],
+      sig: "a",
+    };
+
+    expect(transformLatticeContractToContractRecord(mockDef)).toStrictEqual(
+      expected
+    );
+  });
+});

--- a/src/util/__tests__/localStorage.test.ts
+++ b/src/util/__tests__/localStorage.test.ts
@@ -2,7 +2,10 @@ import localStorage from "../localStorage";
 
 const key = "test";
 const newKey = "newKey"
+const index = "newIndex"
+const indexTwo = "newIndexTwo"
 const value = 1;
+const valueTwo = 2;
 const obj = { [key]: value };
 
 describe("localStorage", () => {
@@ -77,5 +80,17 @@ describe("localStorage", () => {
     expect(localStorage.getLogin()).toStrictEqual({deviceID: key, password: value});
     localStorage.removeLogin();
     expect(localStorage.getLogin()).toStrictEqual({deviceID: null, password: null});
+  });
+
+  test("should store device indexed items", () => {
+    localStorage.setLogin({deviceID: key, password: value});
+    localStorage.setDeviceIndexedItem(index, value)
+    expect(localStorage.getDeviceIndexedItem(index)).toStrictEqual(value);
+    localStorage.setDeviceIndexedItem(indexTwo, valueTwo)
+    expect(localStorage.getDeviceIndexedItem(index)).toStrictEqual(value);
+    localStorage.removeDeviceIndexedItem(indexTwo)
+    expect(localStorage.getDeviceIndexedItem(indexTwo)).toStrictEqual(undefined);
+    localStorage.removeLogin()
+    expect(localStorage.getDeviceIndexedItem(index)).toStrictEqual(undefined);
   });
 });

--- a/src/util/contracts.ts
+++ b/src/util/contracts.ts
@@ -1,0 +1,23 @@
+import { ContractDefinition, ContractRecord, LatticeContract } from "./../types/contracts";
+
+export const transformContractDefinitionToContractRecord = (
+  def: ContractDefinition 
+): ContractRecord => {
+  return {
+    id: def.name,
+    category: "",
+    header: { name: def.name, sig: def.sig, numParam: def.params.length },
+    ...def,
+  };
+};
+
+export const transformLatticeContractToContractRecord = (
+  lc: LatticeContract 
+): ContractRecord => {
+  return {
+    id: lc.header.name,
+    name: lc.header.name,
+    sig: lc.header.sig,
+    ...lc,
+  };
+};

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -28,7 +28,7 @@ export const constants = {
     LOST_PAIRING_ERR: "NOT_PAIRED",
     LOST_PAIRING_MSG: "Cannot find Lattice connection. Please re-connect.",
     BTC_TESTNET: process.env.REACT_APP_BTC_TESTNET || null,
-    KEYRING_LOGOUT_MS: process.env.KEYRING_LOGOUT_MS || 2592000000, // default 30 days
+    KEYRING_LOGOUT_MS: parseInt(process.env.KEYRING_LOGOUT_MS) || 2592000000, // default 30 days
     KEYRING_DATA_PATH: 'gridplus_web_wallet_keyring_logins', // item in localStorage
     ABI_PACK_URL: "https://gridplus.github.io/abi-pack-framework",
     LATTICE_CERT_SIGNER: process.env.REACT_APP_LATTICE_CERT_SIGNER || '0477816e8e83bb17c4309cc2e5aa134c573a5943154940095a423149f7cc0384ad52d33f1b4cd89c967bf211c039202df3a7899cb7543de4738c96a81cfde4b117',

--- a/src/util/localStorage.ts
+++ b/src/util/localStorage.ts
@@ -12,9 +12,9 @@ const ROOT_STORE = process.env.REACT_APP_ROOT_STORE || "gridplus";
 const getItem = (key) => {
   const value = window.localStorage.getItem(key);
   try {
-    return JSON.parse(value)
+    return JSON.parse(value);
   } catch (e) {
-    return JSON.parse(JSON.stringify(value))
+    return JSON.parse(JSON.stringify(value));
   }
 };
 const setItem = (key, value) =>
@@ -95,15 +95,45 @@ const removeLogin = () => {
 
 // #endregion
 
+// #region -- Device Indexed Functions
+
+const getDeviceIndexedItem = (key) => {
+  const deviceId = getLoginId();
+  if (deviceId) {
+    return getRootStoreItem(deviceId)?.[key];
+  }
+};
+
+const setDeviceIndexedItem = (key, value) => {
+  const deviceId = getLoginId();
+  if (deviceId && value) {
+    return setRootStoreItem(deviceId, {
+      ...getRootStoreItem(deviceId),
+      [`${key}`]: value,
+    });
+  }
+};
+
+const removeDeviceIndexedItem = (key) => {
+  const deviceId = getLoginId();
+  if (deviceId) {
+    return setRootStoreItem(deviceId, omit(getRootStoreItem(deviceId), key));
+  }
+};
+
+// #endregion
+
 // #region -- Address & Contracts Functions
 
-const getAddresses = () => getItem(ADDRESSES_STORAGE_KEY) ?? [];
-const setAddresses = (value) => setItem(ADDRESSES_STORAGE_KEY, value);
-const removeAddresses = () => removeItem(ADDRESSES_STORAGE_KEY);
+const getAddresses = () => getDeviceIndexedItem(ADDRESSES_STORAGE_KEY);
+const setAddresses = (value) =>
+  setDeviceIndexedItem(ADDRESSES_STORAGE_KEY, value);
+const removeAddresses = () => removeDeviceIndexedItem(ADDRESSES_STORAGE_KEY);
 
-const getContracts = () => getItem(CONTRACTS_STORAGE_KEY) ?? [];
-const setContracts = (value) => setItem(CONTRACTS_STORAGE_KEY, value);
-const removeContracts = () => removeItem(CONTRACTS_STORAGE_KEY);
+const getContracts = () => getDeviceIndexedItem(CONTRACTS_STORAGE_KEY);
+const setContracts = (value) =>
+  setDeviceIndexedItem(CONTRACTS_STORAGE_KEY, value);
+const removeContracts = () => removeDeviceIndexedItem(CONTRACTS_STORAGE_KEY);
 
 const getContractPacks = () => getItem(CONTRACT_PACKS_STORAGE_KEY) ?? [];
 const setContractPacks = (value) => setItem(CONTRACT_PACKS_STORAGE_KEY, value);
@@ -138,6 +168,9 @@ export default {
   getLogin,
   setLogin,
   removeLogin,
+  getDeviceIndexedItem,
+  setDeviceIndexedItem,
+  removeDeviceIndexedItem,
   getAddresses,
   setAddresses,
   removeAddresses,

--- a/src/util/localStorage.ts
+++ b/src/util/localStorage.ts
@@ -2,6 +2,9 @@ import omit from "lodash/omit";
 
 const LOGIN_ID_STORAGE_KEY = "gridplus_web_wallet_id";
 const LOGIN_PASSWORD_STORAGE_KEY = "gridplus_web_wallet_password";
+const ADDRESSES_STORAGE_KEY = "gridplus_addresses";
+const CONTRACTS_STORAGE_KEY = "gridplus_contracts";
+const CONTRACT_PACKS_STORAGE_KEY = "gridplus_contracts_packs";
 const ROOT_STORE = process.env.REACT_APP_ROOT_STORE || "gridplus";
 
 // #region -- Generic Local Storage Functions
@@ -92,6 +95,22 @@ const removeLogin = () => {
 
 // #endregion
 
+// #region -- Address & Contracts Functions
+
+const getAddresses = () => getItem(ADDRESSES_STORAGE_KEY) ?? [];
+const setAddresses = (value) => setItem(ADDRESSES_STORAGE_KEY, value);
+const removeAddresses = () => removeItem(ADDRESSES_STORAGE_KEY);
+
+const getContracts = () => getItem(CONTRACTS_STORAGE_KEY) ?? [];
+const setContracts = (value) => setItem(CONTRACTS_STORAGE_KEY, value);
+const removeContracts = () => removeItem(CONTRACTS_STORAGE_KEY);
+
+const getContractPacks = () => getItem(CONTRACT_PACKS_STORAGE_KEY) ?? [];
+const setContractPacks = (value) => setItem(CONTRACT_PACKS_STORAGE_KEY, value);
+const removeContractPacks = () => removeItem(CONTRACT_PACKS_STORAGE_KEY);
+
+// #endregion
+
 export default {
   getItem,
   setItem,
@@ -119,4 +138,13 @@ export default {
   getLogin,
   setLogin,
   removeLogin,
+  getAddresses,
+  setAddresses,
+  removeAddresses,
+  getContracts,
+  setContracts,
+  removeContracts,
+  getContractPacks,
+  setContractPacks,
+  removeContractPacks,
 };


### PR DESCRIPTION
In order to cache data that takes a long time to fetch (addresses and contract data), I've added a global context, `AppContext`, to the app to store that data and some other bits that are helpful for managing that data.

To make it a bit easier to manage and share logic, I've moved the code that interfaces with the 
`gridplus-sdk` out into reusable React hooks (`useAddresses` and `useContracts`). There is also a small hook, `useRequestFailed`, that is used for shared code between the two. All of these hooks also have their own tests. 

`isMobile` and `session` which were passed throughout the app as props up and down the component tree have been moved into the `AppContext`. To do so, the Class-based components had their `contextType` specified as `AppContext` which makes available `this.context` inside those classes so they can access the context to retrieve `isMobile`.

The tests have been updated to use a `MockProvider` which mocks out the `AppContext` and allows us to test the components in isolation. 

