### PR TITLE
Removes v0.15 boolean and swaps to using `useFeature` hook

### DIFF
--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -11,7 +11,6 @@ import { PageContent } from "./index";
 
 const Landing = () => {
   const { USES_AUTO_ABI } = useFeature();
-  const is15Released = false; //TODO: Activate when fw v15 is released
 
   return (
     <PageContent>
@@ -43,7 +42,7 @@ const Landing = () => {
         <p>
           <i>Give names to your favorite contracts or recipient addresses.</i>
         </p>
-        {is15Released && !USES_AUTO_ABI ? (
+        {!USES_AUTO_ABI ? (
           <Alert
             style={{ maxWidth: "500px", margin: "auto" }}
             message="Lattice firmware is out of date"

--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -1,17 +1,17 @@
-import { DesktopOutlined, TagsOutlined } from "@ant-design/icons";
+import {
+  DesktopOutlined,
+  TagsOutlined
+} from "@ant-design/icons";
 import { Alert, Card, Divider } from "antd";
 import "antd/dist/antd.dark.css";
-import React, { useContext } from "react";
-import SDKSession from "../sdk/sdkSession";
-import { AppContext } from "../store/AppContext";
+import React from "react";
+import { useFeature } from "../hooks/useFeature";
 import { constants } from "../util/helpers";
 import { PageContent } from "./index";
 
 const Landing = () => {
-  const { session } = useContext(AppContext) as { session: SDKSession };
-  const is15Released = false //TODO: Activate when fw v15 is released
-  const fwVersion = session?.client?.getFwVersion();
-  const doesSupportGenericSigning = fwVersion.minor < 15;
+  const { USES_AUTO_ABI } = useFeature();
+  const is15Released = false; //TODO: Activate when fw v15 is released
 
   return (
     <PageContent>
@@ -43,7 +43,7 @@ const Landing = () => {
         <p>
           <i>Give names to your favorite contracts or recipient addresses.</i>
         </p>
-        {is15Released && doesSupportGenericSigning ? (
+        {is15Released && !USES_AUTO_ABI ? (
           <Alert
             style={{ maxWidth: "500px", margin: "auto" }}
             message="Lattice firmware is out of date"

--- a/src/hooks/useFeature.tsx
+++ b/src/hooks/useFeature.tsx
@@ -14,6 +14,7 @@ export const useFeature = (): { [feature: string]: boolean } => {
 
   const features = {
     CAN_VIEW_CONTRACTS: [0, 14, 0],
+    USES_AUTO_ABI: [0, 15, 0],
   };
 
   return Object.fromEntries(


### PR DESCRIPTION
**NOTE**: Wait to merge until we've swapped over dns to older deployment

Also, I forgot about the `useFeature` hook that we made for feature flags which is exactly what we needed to manage the contract alert. 