### PR TITLE
Fixes crash on missing external wallet

### DIFF
--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -593,7 +593,7 @@ class Main extends React.Component<any, MainState> {
     const size = this.isMobile() ? 'small' : 'middle';
     const activeWallet = this.context.session.getActiveWallet();
 
-    if (activeWallet === null) {
+    if (!activeWallet) {
       walletTag = ( 
         //@ts-expect-error - danger type is missing in antd
         <Button type="danger" ghost onClick={this.refreshWallets} size={size}>No Wallet <ReloadOutlined/></Button>


### PR DESCRIPTION
- ActiveWallet response changed from null to undefined. 
- We were checking for null only. 
- Now we're checking for any falsey value.