### PR TITLE
Adds POAP claiming to validate page

### DIFF
--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -36,6 +36,7 @@ export const constants = {
     CONTRACTS_HELP_LINK: 'https://docs.gridplus.io/gridplus-web-wallet/use-ethereum-smart-contract-abi-function-definitions',
     TAGS_HELP_LINK: 'https://docs.gridplus.io/gridplus-web-wallet/address-tags',
     PERMISSIONS_HELP_LINK: 'https://docs.gridplus.io/gridplus-web-wallet/how-to-set-and-use-spending-limits',
+    POAP_CLAIM_REMOTE_URL: 'https://us-central1-lattice-poap.cloudfunctions.net/validate',
     BTC_WALLET_STORAGE_KEY: 'btc_wallet',
     BTC_PURPOSE_NONE: -1,
     BTC_PURPOSE_NONE_STR: 'Hide BTC Wallet',


### PR DESCRIPTION
To test:

- Tap `Validate Lattice`
- Enter `poap` or `POAP` as message (or another easter egg value)
- Scan QR code. 
- Boot up this branch.
- Replace `https://lattice.gridplus.io` in scanned QR with `localhost:3000`
- Visit new `localhost` url.
- Click `Claim` button.
- Visit generated link.
- Refresh page.
- Click `Claim` button again, the same link should be generated.