### PR TITLE
Removes check for ref===master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,6 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
 
     steps:
       - name: Download artifact


### PR DESCRIPTION
To deploy, we used to check if we were on `master` branch. Because we're now using Releases, the `ref` will point to the git tag of the release, rather than `master` branch.