### PR TITLE
Adds support for additional csv headers

### DIFF
--- a/src/util/csv.ts
+++ b/src/util/csv.ts
@@ -1,13 +1,40 @@
 import Papa from "papaparse";
 import { Address } from "../types/records";
 
-export const addressesToCsvString = (addresses: Address[]): string => Papa.unparse(
-  addresses.map((address) => ({ key: address.key, val: address.val }))
-);
+export const getAddressKey = (address): string => {
+  if (address.Name) return address.Name;
+  if (address.name) return address.name;
+  if (address.Key) return address.Key;
+  if (address.key) return address.key;
+  return "";
+};
+
+export const getAddressVal = (address): string => {
+  if (address.Address) return address.Address;
+  if (address.address) return address.address;
+  if (address.Val) return address.Val;
+  if (address.val) return address.val;
+  return "";
+};
+
+export const addressesToCsvString = (addresses: any[]): string => {
+  const addressList = addresses.map((address) => {
+    return {
+      name: address.key,
+      address: address.val,
+    };
+  });
+  return Papa.unparse(addressList);
+};
 
 export const csvStringToAddresses = (text: string): Address[] => {
   const result = Papa.parse(text, {
     header: true,
-  })
-  return result?.data
-}
+  });
+  return result?.data.map((address) => {
+    return {
+      key: getAddressKey(address),
+      val: getAddressVal(address),
+    };
+  });
+};


### PR DESCRIPTION
- In addition to `{ key, val }`, adds support for any combination of the following headers: 
	- Name
	- name
	- Key
	- Address
	- address
	- Val
- Sets default csv export headers to `{ name, address }`