### PR TITLE
Changes default behavior for failed pairing to exit (fixes #298)

### DIFF
--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -15,6 +15,7 @@ import localStorage from '../util/localStorage';
 import { AppContext } from '../store/AppContext';
 import ExplorerPage from './ExplorerPage';
 import type { MenuProps } from 'antd/es/menu';
+import { sendErrorNotification } from '../util/sendErrorNotification';
 type MenuItem = Required<MenuProps>['items'][number];
 
 const { Content, Footer, Sider } = Layout;
@@ -484,10 +485,16 @@ class Main extends React.Component<any, MainState> {
         }
       })
       .catch((err) => {
-        // If there was an error here, the user probably entered the wrong secret
-        const pairErr =
-          "Failed to pair. You either entered the wrong code or have already connected to this app.";
-        this.setError({ msg: pairErr, cb: this.connectSession });
+         // If there was an error here, the user probably entered the wrong secret
+         sendErrorNotification({
+          message: "Failed to pair",
+          description: "You may have mistyped the pairing code, or this device is already paired and you entered the incorrect password. Please try again.",
+          duration: null, // Don't auto-dismiss
+        });
+        this.setState({ deviceID: null, password: null })
+        this.context.session.disconnect()
+        localStorage.removeLogin();
+        this.unwait();
       });
   }
 

--- a/src/util/sendErrorNotification.tsx
+++ b/src/util/sendErrorNotification.tsx
@@ -5,11 +5,13 @@ export const sendErrorNotification = ({
   description,
   onClick,
   onClose,
+  duration = 4.5
 }: {
   message: string;
   description?: string;
   onClick?: () => void;
   onClose?: () => void;
+  duration?: number; // in seconds
 }) => {
   const key = `error-${Date.now()}`;
   const btn = onClick && (
@@ -27,6 +29,7 @@ export const sendErrorNotification = ({
   notification.open({
     message,
     description,
+    duration,
     placement: "top",
     btn,
     key,


### PR DESCRIPTION
Instead of automatically retrying or letting the user click "Retry" button, it automatically fails out and goes back to the Connect form with empty inputs to try again.